### PR TITLE
[WIP] Add-on rewards chest

### DIFF
--- a/scripts/zones/Lower_Jeuno/npcs/Treasure_Coffer.lua
+++ b/scripts/zones/Lower_Jeuno/npcs/Treasure_Coffer.lua
@@ -34,19 +34,130 @@ local optionToKI =
     [20] = xi.ki.TONBERRY_KEY,
 }
 
+local optionToGear =
+{
+    --ACP
+    [1] = {addon = 1, itemid = 11313}, -- nuevo_coselete
+    [2] = {addon = 1, itemid = 11314}, -- mirke_wardecors
+    [3] = {addon = 1, itemid = 11315}, -- royal_redingote
+    --AMK
+    [4] = {addon = 2, itemid = 11487}, -- champions_galea
+    [5] = {addon = 2, itemid = 11488}, -- anwig_salade
+    [6] = {addon = 2, itemid = 11489}, -- selenian_cap
+    --ASA
+    [7] = {addon = 3, itemid = 16369}, -- blitzer_poleyn
+    [8] = {addon = 3, itemid = 16370}, -- desultor_tassets
+    [9] = {addon = 3, itemid = 16371}, -- tatsumaki_sitagoromo
+}
+
+
+local optionToAugment =
+{
+    [1] = -- ACP
+    {
+        [ 1] = {{augment =  23, power =  9}}, -- Accuracy+10
+        [ 2] = {{augment =  25, power =  9}}, -- Attack+10
+        [ 3] = {{augment =  27, power =  9}}, -- Ranged Accuracy+10
+        [ 4] = {{augment =  29, power =  9}}, -- Ranged Attack+10
+        [ 5] = {{augment =  31, power =  9}}, -- Evasion+10
+        [ 6] = {{augment =  35, power =  3}}, -- Magic Accuracy+4
+        [ 7] = {{augment = 133, power =  3}}, -- "Magic Atk, Bonus"+4
+        [ 8] = {{augment = 143, power =  1}}, -- "Double Attack"+2
+        [ 9] = {{augment =  41, power =  2}}, -- Critical hit rate +3
+        [10] = {{augment =  44, power =  3}}, -- Store TP"+4 "Subtle Blow"+4
+        [11] = {{augment =  39, power =  4}}, -- Enmity+5
+        [12] = {{augment =  40, power =  4}}, -- Enmity-5
+        [13] = {{augment = 140, power =  4}}, -- Enhances "Fast Cast" effect +5
+        [14] = {{augment = 324, power = 14}}, -- "Call Beast" ability delay -15
+        [15] = {{augment = 211, power =  4}}, -- "Snapshot"+5
+        [16] = {{augment = 146, power =  2}}, -- Enhances "Dual Wield" effect +3
+        [17] = {{augment = 320, power =  3}}, -- "Blood Pact" ability delay -4
+        [18] = {{augment = 321, power =  1}}, -- Avatar perpetuation cost -2
+        [19] = {{augment = 325, power =  4}}, -- Quick Draw" ability delay -5
+        [20] = {{augment =  96, power = 14}}, -- Pet: Accuracy+15 Ranged Accuracy+15
+        [21] = {{augment =  97, power = 14}}, -- Pet: Attack+15 Ranged Attack+15
+        [22] = {{augment = 108, power =  6}}, -- Pet: Magic Acc.+7 "Magic Atk. Bonus"+7
+        [23] = {{augment = 109, power =  1}}, -- Pet: "Double Attack"+2 Crit. hit rate +2
+    },
+    [2] = -- AMK
+    {
+        [ 1] = {{augment = 49, power =  2}, {augment = 211, power =  2}}, -- Haste+3 "Snapshot"+3
+        [ 2] = {{augment = 512, power = 3}, {augment = 326, power = 14}}, -- STR+4 Weapon Skill Accuracy +15
+        [ 3] = {{augment = 513, power = 3}, {augment = 328, power =  1}}, -- DEX+4 Increases Critical Hit Damage (+2%)
+        [ 4] = {{augment = 514, power = 3}, {augment = 286, power =  4}}, -- VIT+4 Shield Skill +5
+        [ 5] = {{augment = 515, power = 3}, {augment = 327, power =  1}}, -- AGI+4 Increases weapon skill damage (+2%)
+        [ 6] = {{augment = 516, power = 3}, {augment =  35, power =  1}}, -- INT+4 Magic Accuracy+2
+        [ 7] = {{augment = 517, power = 3}, {augment = 329, power =  2}}, -- MND+4 "Cure" potency +3%
+        [ 8] = {{augment = 518, power = 3}, {augment = 331, power =  1}}, -- CHR+4 "Waltz" ability delay -2
+        [ 9] = {{augment =  23, power = 9}, {augment =  25, power =  4}}, -- Accuracy+10 Attack+5
+        [10] = {{augment =  27, power = 9}, {augment =  29, power =  4}}, -- Ranged Accuracy+10 Ranged Attack+5
+        [11] = {{augment =  31, power = 9}, {augment = 142, power =  3}}, -- Evasion+10 Store TP +4
+        [12] = {{augment =  35, power = 2}, {augment =  52, power =  2}}, -- Magic Accuracy+3 MP recovered while healing +3
+        [13] = {{augment = 133, power = 1}, {augment =  51, power =  2}}, -- "Magic Attack Bonus"+2 HP recovered while healing +3
+        [14] = {{augment =  55, power = 1}, {augment =  39, power =  3}}, -- Magic damage taken -2% Enmity+4
+        [15] = {{augment =  57, power = 9}, {augment =  40, power =  3}}, -- Magic critical hit rate +10% Enmity-4
+        [16] = {{augment = 140, power = 2}, {augment = 320, power =  2}}, -- Enhances "Fast Cast" effect (+3%) "Blood Pact" ability delay -3
+        [17] = {{augment = 512, power = 1}, {augment =  49, power =  1}}, -- STR+2 Haste +2%
+        [18] = {{augment = 513, power = 1}, {augment =  49, power =  1}}, -- DEX+2 Haste +2%
+        [19] = {{augment = 514, power = 1}, {augment =  49, power =  1}}, -- VIT+2 Haste +2%
+        [20] = {{augment = 515, power = 1}, {augment =  49, power =  1}}, -- AGI+2 Haste +2%
+        [21] = {{augment = 516, power = 1}, {augment = 140, power =  1}}, -- INT+2 Enhances "Fast Cast" effect (+2%)
+        [22] = {{augment = 517, power = 1}, {augment = 140, power =  1}}, -- MND+2 Enhances "Fast Cast" effect (+2%)
+        [23] = {{augment = 518, power = 1}, {augment = 140, power =  1}}, -- CHR+2 Enhances "Fast Cast" effect (+2%)
+        [24] = {{augment =  23, power = 2}, {augment = 111, power =  4}}, -- Accuracy+3 Pet: Haste +5%
+        [25] = {{augment =  23, power = 2}, {augment = 102, power =  2}}, -- Accuracy+3 Pet: Critical Hit Rate +3%
+        [26] = {{augment =  25, power = 2}, {augment = 110, power =  0}}, -- Attack+3 Pet: Adds "Regen" effect
+        [27] = {{augment =  25, power = 2}, {augment = 112, power =  9}}, -- Attack+3 Pet: Damage taken -10%
+    },
+    [3] = -- ASA
+    {
+        [ 1] = {{augment =   1, power = 24}, {augment = 39, power =  3}}, -- HP+25 Enmity+4
+        [ 2] = {{augment =   9, power = 24}, {augment = 40, power =  3}}, -- MP+25 Enmity-4
+        [ 3] = {{augment =  23, power =  6}                            }, -- Accuracy+7
+        [ 4] = {{augment =  25, power =  6}                            }, -- Attack+7
+        [ 5] = {{augment =  27, power =  6}                            }, -- Ranged Accuracy+7
+        [ 6] = {{augment =  29, power =  6}                            }, -- Ranged Attack+7
+        [ 7] = {{augment =  31, power =  6}                            }, -- Evasion+7
+        [ 8] = {{augment =  35, power =  3}                            }, -- Magic Accuracy+4
+        [ 9] = {{augment = 133, power =  3}                            }, -- "Magic Atk. Bonus" +4
+        [10] = {{augment =  49, power =  2}                            }, -- Haste +3%
+        [11] = {{augment = 143, power =  1}                            }, -- "Double Attack" +2%
+        [12] = {{augment = 328, power =  2}                            }, -- Increases Critical Hit Damage +3%
+        [13] = {{augment = 332, power =  4}                            }, -- Skillchain damage +5%
+        [14] = {{augment = 333, power =  4}                            }, -- "Conserve TP"+5
+        [15] = {{augment =  54, power =  3}                            }, -- Physical damage taken -4%
+        [16] = {{augment = 335, power =  9}                            }, -- Magic Critical Hit damage +10%
+        [17] = {{augment = 334, power =  9}                            }, -- Magic Burst damage +10%
+        [18] = {{augment = 194, power =  4}                            }, -- "Kick Attacks" +5
+        [19] = {{augment = 329, power =  4}                            }, -- "Cure" potency +5%
+        [20] = {{augment = 336, power =  4}                            }, -- "Sic" & "Ready" ability delay -5     (TODO Add into Augments with modID)
+        [21] = {{augment = 337, power =  2}                            }, -- Song Recast Delay -3
+        [22] = {{augment = 338, power =  0}                            }, -- "Barrage" +1                         (TODO Add into Augments with modID)
+        [23] = {{augment = 339, power =  3}                            }, -- "Elemental Siphon" +20
+        [24] = {{augment = 340, power =  4}                            }, -- "Phantom Roll" ability delay -5      (TODO Add into Augments with modID)
+        [25] = {{augment = 341, power =  9}                            }, -- "Repair" potency +10%
+        [26] = {{augment = 342, power =  4}                            }, -- "Waltz" TP cost -50                  (TODO Add into Augments with modID)
+        [27] = {{augment =  96, power =  6}                            }, -- Pet: Accuracy +7 Ranged Accuracy +7
+        [28] = {{augment =  97, power =  6}                            }, -- Pet: Attack +7 Ranged Attack +7
+        [29] = {{augment = 115, power =  7}, {augment = 116, power = 7}}, -- Pet: "Store TP" +8 "Subtle Blow" +8
+        [30] = {{augment = 100, power =  6}                            }, -- Pet: Magic Accuracy +7
+        [31] = {{augment = 913, power =  2}                            }, -- Movement Speed +8%
+    },
+}
+
 local prizes =
 {
     [xi.ki.CRIMSON_KEY] =
     {
-        {cutoff =   70, itemId = 13206, augments = {{9, 0,  5}, {516, 0, 1}, {517, 0, 1}, {518, 0, 1}, { 32, 0, 1}, { 96, 0, 1}}}, -- Gold Obi
-        {cutoff =   80, itemId = 13445, augments = {{9, 0,  8}, {516, 0, 1}, {517, 0, 1}, {518, 0, 2}, { 39, 0, 1}, { 35, 0, 2}}}, -- Gold Ring
-        {cutoff =  186, itemId = 13446, augments = {{1, 0, 15}, { 13, 0, 2}, { 25, 0, 5}, { 31, 0, 2}, {195, 0, 1}, { 35, 0, 2}}}, -- Mythril Ring
-        {cutoff =  276, itemId = 13643, augments = {{9, 0,  5}, {516, 0, 1}, {517, 0, 1}, {518, 0, 1}, {100, 0, 1}, { 39, 0, 1}}}, -- Sarcenet Cape
-        {cutoff =  351, itemId = 13196, augments = {{1, 0,  5}, { 23, 0, 1}, { 27, 0, 1}, {512, 0, 1}, {520, 0, 1}, {515, 0, 1}}}, -- Silver Belt
-        {cutoff =  460, itemId = 13571, augments = {{1, 0,  5}, { 25, 0, 3}, { 29, 0, 3}, {512, 0, 0}, {769, 0, 1}, { 32, 0, 1}}}, -- Wolf Mantle
-        {cutoff =  468, itemId =   694}, -- Chestnut Log
-        {cutoff =  471, itemId =   887}, -- Coral Fragment
-        {cutoff =  476, itemId =  4903}, -- Dark Spirit Pact
+         {cutoff =   70, itemId = 13206, augments = {{9, 0,  5}, {516, 0, 1}, {517, 0, 1}, {518, 0, 1}, { 32, 0, 1}, { 96, 0, 1}}}, -- Gold Obi
+         {cutoff =   80, itemId = 13445, augments = {{9, 0,  8}, {516, 0, 1}, {517, 0, 1}, {518, 0, 2}, { 39, 0, 1}, { 35, 0, 2}}}, -- Gold Ring
+         {cutoff =  186, itemId = 13446, augments = {{1, 0, 15}, { 13, 0, 2}, { 25, 0, 5}, { 31, 0, 2}, {195, 0, 1}, { 35, 0, 2}}}, -- Mythril Ring
+         {cutoff =  276, itemId = 13643, augments = {{9, 0,  5}, {516, 0, 1}, {517, 0, 1}, {518, 0, 1}, {100, 0, 1}, { 39, 0, 1}}}, -- Sarcenet Cape
+         {cutoff =  351, itemId = 13196, augments = {{1, 0,  5}, { 23, 0, 1}, { 27, 0, 1}, {512, 0, 1}, {520, 0, 1}, {515, 0, 1}}}, -- Silver Belt
+         {cutoff =  460, itemId = 13571, augments = {{1, 0,  5}, { 25, 0, 3}, { 29, 0, 3}, {512, 0, 0}, {769, 0, 1}, { 32, 0, 1}}}, -- Wolf Mantle
+         {cutoff =  468, itemId =   694}, -- Chestnut Log
+         {cutoff =  471, itemId =   887}, -- Coral Fragment
+         {cutoff =  476, itemId =  4903}, -- Dark Spirit Pact
         {cutoff =  479, itemId =   654}, -- Darksteel Ingot
         {cutoff =  500, itemId =   645}, -- Darksteel Ore
         {cutoff =  523, itemId =  4868}, -- Scroll of Dispel
@@ -69,15 +180,15 @@ local prizes =
     },
     [xi.ki.VIRIDIAN_KEY] =
     {
-        {cutoff =   65, itemId = 13639}, -- Aurora Mantle
-        {cutoff =  142, itemId = 13271}, -- Corsette
-        {cutoff =  237, itemId = 12364}, -- Nymph Shield
-        {cutoff =  356, itemId = 13570}, -- Ram Mantle
-        {cutoff =  457, itemId = 13198}, -- Swordbelt
-        {cutoff =  463, itemId = 13207}, -- Brocade Obi
-        {cutoff =  469, itemId =   793}, -- Black Pearl
-        {cutoff =  497, itemId =   775}, -- Black Rock
-        {cutoff =  515, itemId =   770}, -- Blue Rock
+         {cutoff =   65, itemId = 13639}, -- Aurora Mantle
+         {cutoff =  142, itemId = 13271}, -- Corsette
+         {cutoff =  237, itemId = 12364}, -- Nymph Shield
+         {cutoff =  356, itemId = 13570}, -- Ram Mantle
+         {cutoff =  457, itemId = 13198}, -- Swordbelt
+         {cutoff =  463, itemId = 13207}, -- Brocade Obi
+         {cutoff =  469, itemId =   793}, -- Black Pearl
+         {cutoff =  497, itemId =   775}, -- Black Rock
+         {cutoff =  515, itemId =   770}, -- Blue Rock
         {cutoff =  616, itemId =  4145}, -- Elixir
         {cutoff =  670, itemId =  4129}, -- Ether +1
         {cutoff =  676, itemId =   790}, -- Garnet
@@ -99,15 +210,15 @@ local prizes =
     },
     [xi.ki.AMBER_KEY] =
     {
-        {cutoff = 111, itemId = 16263}, -- Beak Necklace
-        {cutoff = 219, itemId = 13207}, -- Brocade Obi
-        {cutoff = 334, itemId = 13091}, -- Carapace Gorget
-        {cutoff = 436, itemId = 13445}, -- Gold Ring
-        {cutoff = 561, itemId = 13593}, -- Raptor Mantle
-        {cutoff = 564, itemId =   887}, -- Coral Fragment
-        {cutoff = 576, itemId =   645}, -- Darksteel Ore
-        {cutoff = 599, itemId =   902}, -- Demon Horn
-        {cutoff = 616, itemId =   702}, -- Ebony Log
+         {cutoff = 111, itemId = 16263}, -- Beak Necklace
+         {cutoff = 219, itemId = 13207}, -- Brocade Obi
+         {cutoff = 334, itemId = 13091}, -- Carapace Gorget
+         {cutoff = 436, itemId = 13445}, -- Gold Ring
+         {cutoff = 561, itemId = 13593}, -- Raptor Mantle
+         {cutoff = 564, itemId =   887}, -- Coral Fragment
+         {cutoff = 576, itemId =   645}, -- Darksteel Ore
+         {cutoff = 599, itemId =   902}, -- Demon Horn
+         {cutoff = 616, itemId =   702}, -- Ebony Log
         {cutoff = 625, itemId =   737}, -- Gold Ore
         {cutoff = 683, itemId =  4144}, -- Hi-Elixer
         {cutoff = 730, itemId =  4132}, -- Hi-Ether
@@ -126,15 +237,15 @@ local prizes =
     },
     [xi.ki.AZURE_KEY] =
     {
-        {cutoff = 106, itemId = 13597}, -- Beak Mantle
-        {cutoff = 203, itemId = 13092}, -- Coeurl Gorget
-        {cutoff = 305, itemId = 13447}, -- Platinum Ring
-        {cutoff = 386, itemId = 13208}, -- Rainbow Obi
-        {cutoff = 490, itemId = 13125}, -- Torque
-        {cutoff = 498, itemId =   791}, -- Aquamarine
-        {cutoff = 502, itemId =   801}, -- Chrysoberyl
-        {cutoff = 536, itemId =   654}, -- Darksteel Ingot
-        {cutoff = 612, itemId =   645}, -- Darksteel Ore
+         {cutoff = 106, itemId = 13597}, -- Beak Mantle
+         {cutoff = 203, itemId = 13092}, -- Coeurl Gorget
+         {cutoff = 305, itemId = 13447}, -- Platinum Ring
+         {cutoff = 386, itemId = 13208}, -- Rainbow Obi
+         {cutoff = 490, itemId = 13125}, -- Torque
+         {cutoff = 498, itemId =   791}, -- Aquamarine
+         {cutoff = 502, itemId =   801}, -- Chrysoberyl
+         {cutoff = 536, itemId =   654}, -- Darksteel Ingot
+         {cutoff = 612, itemId =   645}, -- Darksteel Ore
         {cutoff = 659, itemId =   702}, -- Ebony Log
         {cutoff = 693, itemId =   745}, -- Gold Ingot
         {cutoff = 786, itemId =  4144}, -- Hi-Elixir
@@ -151,15 +262,15 @@ local prizes =
     },
     [xi.ki.IVORY_KEY] =
     {
-        {cutoff =   62, itemId = 13357}, -- Angels Earring
-        {cutoff =   70, itemId = 13356}, -- Death Earring
-        {cutoff =  113, itemId = 13353}, -- Diamond Earring
-        {cutoff =  196, itemId = 13351}, -- Emerald Earring
-        {cutoff =  301, itemId = 13352}, -- Ruby Earring
-        {cutoff =  392, itemId = 13355}, -- Sapphire Earring
-        {cutoff =  478, itemId = 13354}, -- Spinel Earring
-        {cutoff =  497, itemId = 13318}, -- Topaz Earring
-        {cutoff =  546, itemId =  1110}, -- Beetle Blood
+         {cutoff =   62, itemId = 13357}, -- Angels Earring
+         {cutoff =   70, itemId = 13356}, -- Death Earring
+         {cutoff =  113, itemId = 13353}, -- Diamond Earring
+         {cutoff =  196, itemId = 13351}, -- Emerald Earring
+         {cutoff =  301, itemId = 13352}, -- Ruby Earring
+         {cutoff =  392, itemId = 13355}, -- Sapphire Earring
+         {cutoff =  478, itemId = 13354}, -- Spinel Earring
+         {cutoff =  497, itemId = 13318}, -- Topaz Earring
+         {cutoff =  546, itemId =  1110}, -- Beetle Blood
         {cutoff =  602, itemId =   823}, -- Gold Thread
         {cutoff =  627, itemId =  1465}, -- Granite
         {cutoff =  658, itemId =  4134}, -- Hi-Ether +2
@@ -173,15 +284,15 @@ local prizes =
     },
     [xi.ki.EBON_KEY] =
     {
-        {cutoff =  31, itemId = 13463}, -- Angels Ring
-        {cutoff =  82, itemId = 13462}, -- Death Ring
-        {cutoff = 174, itemId = 13450}, -- Diamond Ring
-        {cutoff = 225, itemId = 13448}, -- Emerald Ring
-        {cutoff = 296, itemId = 13449}, -- Ruby Ring
-        {cutoff = 357, itemId = 13452}, -- Sapphire Ring
-        {cutoff = 459, itemId = 13451}, -- Spinel Ring
-        {cutoff = 500, itemId = 13453}, -- Topaz Ring
-        {cutoff = 510, itemId =   655}, -- Adaman Ingot
+         {cutoff =  31, itemId = 13463}, -- Angels Ring
+         {cutoff =  82, itemId = 13462}, -- Death Ring
+         {cutoff = 174, itemId = 13450}, -- Diamond Ring
+         {cutoff = 225, itemId = 13448}, -- Emerald Ring
+         {cutoff = 296, itemId = 13449}, -- Ruby Ring
+         {cutoff = 357, itemId = 13452}, -- Sapphire Ring
+         {cutoff = 459, itemId = 13451}, -- Spinel Ring
+         {cutoff = 500, itemId = 13453}, -- Topaz Ring
+         {cutoff = 510, itemId =   655}, -- Adaman Ingot
         {cutoff = 541, itemId =   813}, -- Angelstone
         {cutoff = 561, itemId =   645}, -- Darksteel Ore
         {cutoff = 592, itemId =   812}, -- Deathstone
@@ -201,15 +312,15 @@ local prizes =
     },
     [xi.ki.WHITE_CORAL_KEY] =
     {
-        {cutoff =   31, itemId = 12433}, -- Brass Mask
-        {cutoff =  109, itemId = 12986}, -- Chestnut Sabots
-        {cutoff =  218, itemId = 12721}, -- Cotton Gloves
-        {cutoff =  296, itemId = 12826}, -- Studded Trousers
-        {cutoff =  437, itemId = 12602}, -- Wool Robe
-        {cutoff =  468, itemId =   694}, -- Chestnut Log
-        {cutoff =  499, itemId =   645}, -- Darksteel Ore
-        {cutoff =  624, itemId =  4145}, -- Elixir
-        {cutoff =  655, itemId =   690}, -- Elm Log
+         {cutoff =   31, itemId = 12433}, -- Brass Mask
+         {cutoff =  109, itemId = 12986}, -- Chestnut Sabots
+         {cutoff =  218, itemId = 12721}, -- Cotton Gloves
+         {cutoff =  296, itemId = 12826}, -- Studded Trousers
+         {cutoff =  437, itemId = 12602}, -- Wool Robe
+         {cutoff =  468, itemId =   694}, -- Chestnut Log
+         {cutoff =  499, itemId =   645}, -- Darksteel Ore
+         {cutoff =  624, itemId =  4145}, -- Elixir
+         {cutoff =  655, itemId =   690}, -- Elm Log
         {cutoff =  686, itemId =   643}, -- Iron Ore
         {cutoff =  717, itemId =   651}, -- Iron Ingot
         {cutoff =  764, itemId =   653}, -- Mythril Ingot
@@ -224,15 +335,15 @@ local prizes =
     },
     [xi.ki.BLUE_CORAL_KEY] =
     {
-        {cutoff =   42, itemId = 12571}, -- Cuir Bouilli
-        {cutoff =  250, itemId = 14118}, -- Iron Greaves
-        {cutoff =  292, itemId = 12866}, -- Linen Slacks
-        {cutoff =  375, itemId = 12450}, -- Padded Cap
-        {cutoff =  458, itemId = 12731}, -- Velvet Cuffs
-        {cutoff =  500, itemId =   793}, -- Black Pearl
-        {cutoff =  583, itemId =  4145}, -- Elixir
-        {cutoff =  625, itemId =  4129}, -- Ether +1
-        {cutoff =  667, itemId =   790}, -- Garnet
+         {cutoff =   42, itemId = 12571}, -- Cuir Bouilli
+         {cutoff =  250, itemId = 14118}, -- Iron Greaves
+         {cutoff =  292, itemId = 12866}, -- Linen Slacks
+         {cutoff =  375, itemId = 12450}, -- Padded Cap
+         {cutoff =  458, itemId = 12731}, -- Velvet Cuffs
+         {cutoff =  500, itemId =   793}, -- Black Pearl
+         {cutoff =  583, itemId =  4145}, -- Elixir
+         {cutoff =  625, itemId =  4129}, -- Ether +1
+         {cutoff =  667, itemId =   790}, -- Garnet
         {cutoff =  709, itemId =   788}, -- Peridot
         {cutoff =  751, itemId =  4113}, -- Potion +1
         {cutoff =  876, itemId =   669}, -- Oak Log
@@ -242,15 +353,15 @@ local prizes =
     },
     [xi.ki.PEACH_CORAL_KEY] =
     {
-        {cutoff =   66, itemId = 13712}, -- Carapace Harness
-        {cutoff =  198, itemId = 12956}, -- Raptor Ledelsens
-        {cutoff =  303, itemId = 12476}, -- Silk Hat
-        {cutoff =  395, itemId = 14003}, -- Steel Finger Gauntlets
-        {cutoff =  487, itemId = 12867}, -- White Slacks
-        {cutoff =  500, itemId =   645}, -- Darksteel Ore
-        {cutoff =  526, itemId =   902}, -- Demon Horn
-        {cutoff =  565, itemId =   702}, -- Ebony Log
-        {cutoff =  591, itemId =   737}, -- Gold Ore
+         {cutoff =   66, itemId = 13712}, -- Carapace Harness
+         {cutoff =  198, itemId = 12956}, -- Raptor Ledelsens
+         {cutoff =  303, itemId = 12476}, -- Silk Hat
+         {cutoff =  395, itemId = 14003}, -- Steel Finger Gauntlets
+         {cutoff =  487, itemId = 12867}, -- White Slacks
+         {cutoff =  500, itemId =   645}, -- Darksteel Ore
+         {cutoff =  526, itemId =   902}, -- Demon Horn
+         {cutoff =  565, itemId =   702}, -- Ebony Log
+         {cutoff =  591, itemId =   737}, -- Gold Ore
         {cutoff =  696, itemId =  4144}, -- Hi-Elixer
         {cutoff =  747, itemId =  4132}, -- Hi-Ether
         {cutoff =  773, itemId =  4116}, -- Hi-Potion
@@ -268,15 +379,15 @@ local prizes =
     },
     [xi.ki.BLACK_CORAL_KEY] =
     {
-        {cutoff =   90, itemId = 13698}, -- Beak Helm
-        {cutoff =  194, itemId = 12988}, -- Pigaches
-        {cutoff =  224, itemId = 12811}, -- Darksteel Breeches
-        {cutoff =  433, itemId = 12707}, -- Scorpion Mitts
-        {cutoff =  552, itemId = 12604}, -- Silk Coat
-        {cutoff =  597, itemId =   645}, -- Darksteel Ore
-        {cutoff =  612, itemId =   654}, -- Darksteel Ingot
-        {cutoff =  642, itemId =   745}, -- Gold Ingot
-        {cutoff =  776, itemId =  4144}, -- Hi-Elixer
+         {cutoff =   90, itemId = 13698}, -- Beak Helm
+         {cutoff =  194, itemId = 12988}, -- Pigaches
+         {cutoff =  224, itemId = 12811}, -- Darksteel Breeches
+         {cutoff =  433, itemId = 12707}, -- Scorpion Mitts
+         {cutoff =  552, itemId = 12604}, -- Silk Coat
+         {cutoff =  597, itemId =   645}, -- Darksteel Ore
+         {cutoff =  612, itemId =   654}, -- Darksteel Ingot
+         {cutoff =  642, itemId =   745}, -- Gold Ingot
+         {cutoff =  776, itemId =  4144}, -- Hi-Elixer
         {cutoff =  821, itemId =  4133}, -- Hi-Ether +1
         {cutoff =  851, itemId =  4117}, -- Hi-Potion +1
         {cutoff =  866, itemId =   700}, -- Mahogany Log
@@ -287,15 +398,15 @@ local prizes =
     },
     [xi.ki.RED_CORAL_KEY] =
     {
-        {cutoff =  109, itemId = 16289}, -- Alloy Torque
-        {cutoff =  200, itemId = 16288}, -- Aureate Necklace
-        {cutoff =  273, itemId = 16290}, -- Burly Gorget
-        {cutoff =  382, itemId = 16286}, -- Nitid Choker
-        {cutoff =  473, itemId = 16287}, -- Pneuma Collar
-        {cutoff =  528, itemId =  1110}, -- Beetle Blood
-        {cutoff =  619, itemId =   823}, -- Gold Thread
-        {cutoff =  692, itemId =  1465}, -- Granite
-        {cutoff =  728, itemId =  4134}, -- Hi-Ether +2
+         {cutoff =  109, itemId = 16289}, -- Alloy Torque
+         {cutoff =  200, itemId = 16288}, -- Aureate Necklace
+         {cutoff =  273, itemId = 16290}, -- Burly Gorget
+         {cutoff =  382, itemId = 16286}, -- Nitid Choker
+         {cutoff =  473, itemId = 16287}, -- Pneuma Collar
+         {cutoff =  528, itemId =  1110}, -- Beetle Blood
+         {cutoff =  619, itemId =   823}, -- Gold Thread
+         {cutoff =  692, itemId =  1465}, -- Granite
+         {cutoff =  728, itemId =  4134}, -- Hi-Ether +2
         {cutoff =  764, itemId =   837}, -- Malboro Fiber
         {cutoff =  782, itemId =   924}, -- Philosophers Stone
         {cutoff =  800, itemId =   844}, -- Phoenix Feather
@@ -306,15 +417,15 @@ local prizes =
     },
     [xi.ki.ANGEL_SKIN_KEY] =
     {
-        {cutoff =   65, itemId = 16254}, -- Altius Mantle
-        {cutoff =  162, itemId = 16253}, -- Chiffon Cape
-        {cutoff =  243, itemId = 16255}, -- Cortege Cape
-        {cutoff =  356, itemId = 16252}, -- Resilient Mantle
-        {cutoff =  437, itemId = 16256}, -- Rugged Mantle
-        {cutoff =  469, itemId =   646}, -- Adaman Ore
-        {cutoff =  501, itemId =   813}, -- Angelstone
-        {cutoff =  517, itemId =   645}, -- Darksteel Ore
-        {cutoff =  582, itemId =   812}, -- Deathstone
+         {cutoff =   65, itemId = 16254}, -- Altius Mantle
+         {cutoff =  162, itemId = 16253}, -- Chiffon Cape
+         {cutoff =  243, itemId = 16255}, -- Cortege Cape
+         {cutoff =  356, itemId = 16252}, -- Resilient Mantle
+         {cutoff =  437, itemId = 16256}, -- Rugged Mantle
+         {cutoff =  469, itemId =   646}, -- Adaman Ore
+         {cutoff =  501, itemId =   813}, -- Angelstone
+         {cutoff =  517, itemId =   645}, -- Darksteel Ore
+         {cutoff =  582, itemId =   812}, -- Deathstone
         {cutoff =  614, itemId =   787}, -- Diamond
         {cutoff =  646, itemId =   785}, -- Emerald
         {cutoff =  662, itemId =  4135}, -- Hi-Ether +3
@@ -330,24 +441,24 @@ local prizes =
     },
     [xi.ki.MOOGLE_KEY] =
     {
-        {cutoff =  167, itemId = 12442}, -- Studded Bandana
-        {cutoff =  374, itemId = 13209}, -- Chain Belt
-        {cutoff =  707, itemId = 13083}, -- Chain Choker
-        {cutoff =  874, itemId =  4751}, -- Scroll of Erase
-        {cutoff = 1041, itemId =   653}, -- Mythril Ingot
-        {cutoff = 1100, itemId =   744}, -- Silver Ingot
+         {cutoff =  167, itemId = 12442}, -- Studded Bandana
+         {cutoff =  374, itemId = 13209}, -- Chain Belt
+         {cutoff =  707, itemId = 13083}, -- Chain Choker
+         {cutoff =  874, itemId =  4751}, -- Scroll of Erase
+         {cutoff = 1041, itemId =   653}, -- Mythril Ingot
+         {cutoff = 1100, itemId =   744}, -- Silver Ingot
     },
     [xi.ki.BIRD_KEY] =
     {
-        {cutoff = 143, itemId = 12987}, -- Ebony Sabots
-        {cutoff = 393, itemId = 13783}, -- Iron Scale Mail
-        {cutoff = 536, itemId = 12293}, -- Oak Shield
-        {cutoff = 653, itemId = 13200}, -- Waistbelt
-        {cutoff = 663, itemId =   793}, -- Black Pearl
-        {cutoff = 678, itemId =   770}, -- Blue Rock
-        {cutoff = 770, itemId =  4145}, -- Elixir
-        {cutoff = 801, itemId =  4129}, -- Ether +1
-        {cutoff = 816, itemId =   808}, -- Goshenite
+         {cutoff = 143, itemId = 12987}, -- Ebony Sabots
+         {cutoff = 393, itemId = 13783}, -- Iron Scale Mail
+         {cutoff = 536, itemId = 12293}, -- Oak Shield
+         {cutoff = 653, itemId = 13200}, -- Waistbelt
+         {cutoff = 663, itemId =   793}, -- Black Pearl
+         {cutoff = 678, itemId =   770}, -- Blue Rock
+         {cutoff = 770, itemId =  4145}, -- Elixir
+         {cutoff = 801, itemId =  4129}, -- Ether +1
+         {cutoff = 816, itemId =   808}, -- Goshenite
         {cutoff = 847, itemId =   669}, -- Oak Log
         {cutoff = 852, itemId =   792}, -- Pearl
         {cutoff = 862, itemId =   788}, -- Peridot
@@ -361,15 +472,15 @@ local prizes =
     },
     [xi.ki.CACTUAR_KEY] =
     {
-        {cutoff = 109, itemId = 13111}, -- Nodowa
-        {cutoff = 196, itemId = 12604}, -- Silk Coat
-        {cutoff = 305, itemId = 13981}, -- Turtle Bangles
-        {cutoff = 370, itemId = 13711}, -- Carapace Mask
-        {cutoff = 435, itemId =  4132}, -- Hi-Ether
-        {cutoff = 544, itemId =  4144}, -- Hi-Elixer
-        {cutoff = 609, itemId =   645}, -- Darksteel Ore
-        {cutoff = 631, itemId =   737}, -- Gold Ore
-        {cutoff = 674, itemId =  4719}, -- Scroll of Regen III
+         {cutoff = 109, itemId = 13111}, -- Nodowa
+         {cutoff = 196, itemId = 12604}, -- Silk Coat
+         {cutoff = 305, itemId = 13981}, -- Turtle Bangles
+         {cutoff = 370, itemId = 13711}, -- Carapace Mask
+         {cutoff = 435, itemId =  4132}, -- Hi-Ether
+         {cutoff = 544, itemId =  4144}, -- Hi-Elixer
+         {cutoff = 609, itemId =   645}, -- Darksteel Ore
+         {cutoff = 631, itemId =   737}, -- Gold Ore
+         {cutoff = 674, itemId =  4719}, -- Scroll of Regen III
         {cutoff = 696, itemId =  4621}, -- Scroll of Raise II
         {cutoff = 718, itemId =   738}, -- Platinum Ore
         {cutoff = 761, itemId =   866}, -- Wyvern Scales
@@ -382,25 +493,25 @@ local prizes =
     },
     [xi.ki.BOMB_KEY] =
     {
-        {cutoff = 308, itemId = 12980}, -- Battle Boots
-        {cutoff = 462, itemId = 12860}, -- Silk Slops
-        {cutoff = 616, itemId = 13589}, -- Tiger Mantle
-        {cutoff = 693, itemId = 12427}, -- Bascinet
-        {cutoff = 747, itemId =  4144}, -- Hi-Elixer
-        {cutoff = 824, itemId =   654}, -- Darksteel Ingot
-        {cutoff = 901, itemId =   645}, -- Darksteel Ore
+         {cutoff = 308, itemId = 12980}, -- Battle Boots
+         {cutoff = 462, itemId = 12860}, -- Silk Slops
+         {cutoff = 616, itemId = 13589}, -- Tiger Mantle
+         {cutoff = 693, itemId = 12427}, -- Bascinet
+         {cutoff = 747, itemId =  4144}, -- Hi-Elixer
+         {cutoff = 824, itemId =   654}, -- Darksteel Ingot
+         {cutoff = 901, itemId =   645}, -- Darksteel Ore
     },
     [xi.ki.CHOCOBO_KEY] =
     {
-        {cutoff =  190, itemId = 16008}, -- Aptus Earring
-        {cutoff =  285, itemId = 16372}, -- Stearc Subligar
-        {cutoff =  571, itemId = 16295}, -- Varius Torque
-        {cutoff =  595, itemId =   823}, -- Gold Thread
-        {cutoff =  643, itemId =  4134}, -- Hi-Ether +2
-        {cutoff =  714, itemId =  4118}, -- Hi-Potion +2
-        {cutoff =  785, itemId =   837}, -- Malboro Fiber
-        {cutoff =  856, itemId =  1110}, -- Beetle Blood
-        {cutoff =  927, itemId =   924}, -- Philosophers Stone
+         {cutoff =  190, itemId = 16008}, -- Aptus Earring
+         {cutoff =  285, itemId = 16372}, -- Stearc Subligar
+         {cutoff =  571, itemId = 16295}, -- Varius Torque
+         {cutoff =  595, itemId =   823}, -- Gold Thread
+         {cutoff =  643, itemId =  4134}, -- Hi-Ether +2
+         {cutoff =  714, itemId =  4118}, -- Hi-Potion +2
+         {cutoff =  785, itemId =   837}, -- Malboro Fiber
+         {cutoff =  856, itemId =  1110}, -- Beetle Blood
+         {cutoff =  927, itemId =   924}, -- Philosophers Stone
         {cutoff =  995, itemId =   830}, -- Rainbow Cloth
         {cutoff = 1043, itemId =  1132}, -- Raxa
         {cutoff = 1067, itemId =  1465}, -- Granite
@@ -409,15 +520,15 @@ local prizes =
     },
     [xi.ki.TONBERRY_KEY] =
     {
-        {cutoff =  291, itemId = 15938}, -- Esprit Belt
-        {cutoff =  600, itemId = 15937}, -- Fettle Belt
-        {cutoff =  636, itemId =   813}, -- Angelstone
-        {cutoff =  654, itemId =   812}, -- Deathstone
-        {cutoff =  690, itemId =   645}, -- Darksteel Ore
-        {cutoff =  708, itemId =   787}, -- Diamond
-        {cutoff =  744, itemId =   785}, -- Emerald
-        {cutoff =  780, itemId =   823}, -- Gold Thread
-        {cutoff =  798, itemId =  4119}, -- Hi-Potion +3
+         {cutoff =  291, itemId = 15938}, -- Esprit Belt
+         {cutoff =  600, itemId = 15937}, -- Fettle Belt
+         {cutoff =  636, itemId =   813}, -- Angelstone
+         {cutoff =  654, itemId =   812}, -- Deathstone
+         {cutoff =  690, itemId =   645}, -- Darksteel Ore
+         {cutoff =  708, itemId =   787}, -- Diamond
+         {cutoff =  744, itemId =   785}, -- Emerald
+         {cutoff =  780, itemId =   823}, -- Gold Thread
+         {cutoff =  798, itemId =  4119}, -- Hi-Potion +3
         {cutoff =  816, itemId =   738}, -- Platinum Ore
         {cutoff =  834, itemId =   739}, -- Orichalcum Ore
         {cutoff =  870, itemId =   786}, -- Ruby
@@ -477,6 +588,91 @@ local function givePrize(player, ki)
         end
     end
 end
+
+
+function addonGear(player, option, addonReward)
+    local param1     = 0
+    local param2     = 0
+    local param3     = 0
+    local gear       = 0
+    local addon      = 0
+    local parameter1 = optionToAugment[addon][param1]
+    local parameter2 = optionToAugment[addon][param2]
+    local addAug     = {}
+
+    param3   = bit.rshift(option, 21)
+    param2   = bit.rshift(option, 16) - (param3 * 32)
+    param1   = bit.rshift(option, 11) - (param3 * 1024) - (param2 * 32)
+    gear     = bit.rshift(option, 6)  - (param3 * 32768)- (param2 * 1024) - (param1 * 32)
+    addon    = optionToGear[gear].addon
+
+    if addonReward then
+        option = option  - 8388615 -- extra bit passed when recieving armor
+    end
+
+    if addonReward then
+
+        for i = 1, #parameter1 do
+            table.insert(addAug, parameter1[i].augment)
+            table.insert(addAug, parameter1[i].power)
+        end
+
+        for i = 1, #parameter2 do
+            table.insert(addAug, parameter2[i].augment)
+            table.insert(addAug, parameter2[i].power)
+        end
+
+        if player:getFreeSlotsCount() == 0 then
+            player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, optionToGear[gear].itemid)
+
+        else
+
+            player:addItem(optionToGear[gear].itemid, 1, unpack(addAug))
+            player:messageSpecial(ID.text.ITEM_OBTAINED, optionToGear[gear].itemid)
+            player:delKeyItem(({xi.ki.PRISMATIC_KEY, xi.ki.OXBLOOD_KEY, xi.ki.BEHEMOTH_KEY})[addon])
+        end
+
+    else
+
+        for i = 1, #parameter1 do
+            table.insert(addAug, string.format("%05i%011i", intToBinary(parameter1[i].power), intToBinary(parameter1[i].augment)))
+        end
+
+        for i = 1, #parameter2 do
+            table.insert(addAug, string.format("%05i%011i", intToBinary(parameter2[i].power), intToBinary(parameter2[i].augment)))
+        end
+
+        for i = #addAug, 5 do
+            table.insert(addAug, "0000000000000000")
+        end
+
+        if addon == 1 then
+        player:updateEvent(tonumber(addAug[1] .. "0000001100000010", 2), tonumber(addAug[2], 2), tonumber(addAug[3], 2), tonumber(addAug[4] .. addAug[5], 2))
+
+        elseif addon == 2 then
+            player:updateEvent(tonumber(addAug[1] .. "0000001100000010", 2), tonumber(addAug[2] .. addAug[3], 2), tonumber(addAug[4], 2), tonumber(addAug[5], 2))
+
+        elseif addon == 3 then
+            player:updateEvent(tonumber(addAug[1] .. "0000001100000010", 2), tonumber(addAug[2] .. addAug[3], 2), tonumber(addAug[4], 2), tonumber(addAug[5], 2))
+
+        end
+    end
+end
+
+function intToBinary(x)
+
+    local bin = ""
+
+    while x > 1 do
+        bin = tostring(x % 2) .. bin
+        x = math.floor(x / 2)
+    end
+
+    bin = tostring(x) .. bin
+
+    return bin
+end
+
 
 entity.onTrade = function(player, npc, trade)
 end
@@ -540,6 +736,11 @@ entity.onTrigger = function(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option)
+    if csid == 10099 then
+        if option >= 2048 and option < 16777216 then
+            addonGear(player, option, false)
+        end
+    end
 end
 
 entity.onEventFinish = function(player, csid, option)
@@ -562,6 +763,8 @@ entity.onEventFinish = function(player, csid, option)
             if ki ~= nil then
                 givePrize(player, ki)
             end
+        elseif option >= 2048 and option < 16777216 then
+            addonGear(player, option, true)
         end
     end
 end

--- a/sql/augments.sql
+++ b/sql/augments.sql
@@ -1108,7 +1108,7 @@ INSERT INTO `augments` VALUES (909,0,0,0,0,0);
 INSERT INTO `augments` VALUES (910,0,0,0,0,0);
 INSERT INTO `augments` VALUES (911,0,0,0,0,0);
 INSERT INTO `augments` VALUES (912,0,0,0,0,0);
-INSERT INTO `augments` VALUES (913,0,0,0,0,0);
+INSERT INTO `augments` VALUES (913,2,169,2,0,0); -- Movement speed +8%
 INSERT INTO `augments` VALUES (914,0,0,0,0,0);
 INSERT INTO `augments` VALUES (915,0,0,0,0,0);
 INSERT INTO `augments` VALUES (916,0,0,0,0,0);


### PR DESCRIPTION
<!-- remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm: -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] that I agree to LandSandBoat's [Limited Contributor License Agreement](https://github.com/LandSandBoat/server/blob/base/.github/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x] that I have **read the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)**
- [x] that I've _**tested my code and things my code changed**_ since the last commit in the PR, and will test after any later commits

This is the finished version of my augment chest LUA with a edit to SQL to allow the augment of movement speed to be added

This is a TODO WIP until the four augments receive ModID's to implement effects for ASA add-on rewards

AUGMENTS - 336, 338, 340, 342
