### PR TITLE
Kclub Drop Rate and Korrigan Drops. 

### DIFF
--- a/sql/mob_droplist.sql
+++ b/sql/mob_droplist.sql
@@ -3297,7 +3297,7 @@ INSERT INTO `mob_droplist` VALUES (342,0,0,1000,1125,20); -- Carbuncles Ruby (2.
 -- ZoneID: 193 - Thread Leech Fished
 -- ZoneID: 193 - Thread Leech
 INSERT INTO `mob_droplist` VALUES (343,0,0,1000,924,@UNCOMMON); -- Vial Of Fiend Blood (Uncommon, 10%)
-INSERT INTO `mob_droplist` VALUES (343,0,0,1000,1125,20);       -- Carbuncles Ruby (2.0%)
+--INSERT INTO `mob_droplist` VALUES (343,0,0,1000,1125,20);       -- Carbuncles Ruby (2.0%)
 
 -- ZoneID: 169 - Bouncing Ball
 INSERT INTO `mob_droplist` VALUES (344,0,0,1000,924,@UNCOMMON); -- Vial Of Fiend Blood (Uncommon, 10%)

--- a/sql/mob_droplist.sql
+++ b/sql/mob_droplist.sql
@@ -2281,7 +2281,7 @@ INSERT INTO `mob_droplist` VALUES (222,0,0,1000,825,250);        -- Square Of Co
 INSERT INTO `mob_droplist` VALUES (222,0,0,1000,940,@UNCOMMON);  -- Revival Tree Root (Uncommon, 10%)
 INSERT INTO `mob_droplist` VALUES (222,0,0,1000,4871,@UNCOMMON); -- Scroll Of Escape (Uncommon, 10%)
 INSERT INTO `mob_droplist` VALUES (222,2,0,1000,529,20);         -- Luminicloth (2%)
-INSERT INTO `mob_droplist` VALUES (224,2,0,1000,825,0);          -- Square Of Cotton Cloth (Steal)
+INSERT INTO `mob_droplist` VALUES (222,2,0,1000,825,0);          -- Square Of Cotton Cloth (Steal)
 
 -- ZoneID: 157 - Banshee
 INSERT INTO `mob_droplist` VALUES (223,0,0,1000,825,200);        -- Square Of Cotton Cloth (20.0%)

--- a/sql/mob_droplist.sql
+++ b/sql/mob_droplist.sql
@@ -3290,7 +3290,7 @@ INSERT INTO `mob_droplist` VALUES (341,0,0,1000,14763,270);     -- Boroka Earrin
 -- ZoneID: 153 - Bouncing Ball Fished
 INSERT INTO `mob_droplist` VALUES (342,0,0,1000,1125,20); -- Carbuncles Ruby (2.0%)
 
--- ZoneID: 153 - Korrigan
+
 -- ZoneID: 159 - Bouncing Ball Fished
 -- ZoneID: 173 - Thread Leech
 -- ZoneID: 173 - Spool Leech
@@ -3298,7 +3298,7 @@ INSERT INTO `mob_droplist` VALUES (342,0,0,1000,1125,20); -- Carbuncles Ruby (2.
 -- ZoneID: 193 - Thread Leech Fished
 -- ZoneID: 193 - Thread Leech
 INSERT INTO `mob_droplist` VALUES (343,0,0,1000,924,@UNCOMMON); -- Vial Of Fiend Blood (Uncommon, 10%)
---INSERT INTO `mob_droplist` VALUES (343,0,0,1000,1125,20);       -- Carbuncles Ruby (2.0%)
+INSERT INTO `mob_droplist` VALUES (343,0,0,1000,1125,20);       -- Carbuncles Ruby (2.0%)
 
 -- ZoneID: 169 - Bouncing Ball
 INSERT INTO `mob_droplist` VALUES (344,0,0,1000,924,@UNCOMMON); -- Vial Of Fiend Blood (Uncommon, 10%)
@@ -12131,9 +12131,18 @@ INSERT INTO `mob_droplist` VALUES (1461,0,0,1000,5902,30);      -- Vial Of Cageb
 INSERT INTO `mob_droplist` VALUES (1461,0,0,1000,1450,20);      -- Lungo-Nango Jadeshell (2.0%)
 INSERT INTO `mob_droplist` VALUES (1461,2,0,1000,1449,0);       -- Tukuku Whiteshell (Steal)
 
+-- ZoneID: 153 - Korrigan
+INSERT INTO `mob_droplist` VALUES (3228,0,0,1000,1265,12);   -- 4 Leaf Korrigan Bud (1.2%)
+INSERT INTO `mob_droplist` VALUES (3228,0,0,1000,17868,73);  -- Humus (7.3%)
+INSERT INTO `mob_droplist` VALUES (3228,0,0,1000,4368,220);  -- 2 Leaf Mandragora Bud (22%)
+INSERT INTO `mob_droplist` VALUES (3228,4,0,1000,834,0);     -- Saruta Cotton (Despoil)
+INSERT INTO `mob_droplist` VALUES (3228,4,0,1000,4368,0);    -- 2 Leaf Mandragora Bud (despoil)
+
+
 -- ZoneID:  74 - Korrigan
 INSERT INTO `mob_droplist` VALUES (1463,0,0,1000,5378,@UNCOMMON); -- Congestus Cell (Uncommon, 10%)
 INSERT INTO `mob_droplist` VALUES (1463,0,0,1000,5379,@UNCOMMON); -- Nimbus Cell (Uncommon, 10%)
+INSERT INTO `mob_droplist` VALUES (1463,0,0,1000,5376,@UNCOMMON); -- Pannus Cell (Uncommon, 10%)
 
 -- ZoneID:   3 -  Fished
 -- ZoneID:   4 - Kraken Fished

--- a/sql/mob_droplist.sql
+++ b/sql/mob_droplist.sql
@@ -2280,7 +2280,8 @@ INSERT INTO `mob_droplist` VALUES (221,2,0,1000,4362,0);  -- Lizard Egg (Steal)
 INSERT INTO `mob_droplist` VALUES (222,0,0,1000,825,250);        -- Square Of Cotton Cloth (25.0%)
 INSERT INTO `mob_droplist` VALUES (222,0,0,1000,940,@UNCOMMON);  -- Revival Tree Root (Uncommon, 10%)
 INSERT INTO `mob_droplist` VALUES (222,0,0,1000,4871,@UNCOMMON); -- Scroll Of Escape (Uncommon, 10%)
-INSERT INTO `mob_droplist` VALUES (222,2,0,1000,529,20);         -- Luminicloth (Steal)
+INSERT INTO `mob_droplist` VALUES (222,2,0,1000,529,20);         -- Luminicloth (2%)
+INSERT INTO `mob_droplist` VALUES (224,2,0,1000,825,0);          -- Square Of Cotton Cloth (Steal)
 
 -- ZoneID: 157 - Banshee
 INSERT INTO `mob_droplist` VALUES (223,0,0,1000,825,200);        -- Square Of Cotton Cloth (20.0%)

--- a/sql/mob_droplist.sql
+++ b/sql/mob_droplist.sql
@@ -12134,7 +12134,7 @@ INSERT INTO `mob_droplist` VALUES (1461,2,0,1000,1449,0);       -- Tukuku Whites
 INSERT INTO `mob_droplist` VALUES (1463,0,0,1000,5378,@UNCOMMON); -- Congestus Cell (Uncommon, 10%)
 INSERT INTO `mob_droplist` VALUES (1463,0,0,1000,5379,@UNCOMMON); -- Nimbus Cell (Uncommon, 10%)
 
--- ZoneID:   3 - Kraken Fished
+-- ZoneID:   3 -  Fished
 -- ZoneID:   4 - Kraken Fished
 -- ZoneID:   4 - Kraken
 -- ZoneID:   4 - Kraken
@@ -12609,7 +12609,7 @@ INSERT INTO `mob_droplist` VALUES (1535,0,0,1000,15829,92);     -- Skirmishers R
 INSERT INTO `mob_droplist` VALUES (1536,0,0,1000,4484,@ALWAYS); -- Shall Shell (Always, 100%)
 INSERT INTO `mob_droplist` VALUES (1536,0,0,1000,4484,500);     -- Shall Shell (50.0%)
 INSERT INTO `mob_droplist` VALUES (1536,0,0,1000,4484,330);     -- Shall Shell (33.0%)
-INSERT INTO `mob_droplist` VALUES (1536,0,0,1000,18852,@RARE);  -- Octave Club (Rare, 5%)
+INSERT INTO `mob_droplist` VALUES (1536,0,0,1000,17440,10);     -- Kraken Club (Rare, 1%)
 
 -- ZoneID: 217 - Lord Varney
 INSERT INTO `mob_droplist` VALUES (1537,0,0,1000,3197,660);  -- Bale Seal Feet (66.0%)

--- a/sql/mob_droplist.sql
+++ b/sql/mob_droplist.sql
@@ -22395,7 +22395,7 @@ INSERT INTO `mob_droplist` VALUES (2691,2,0,1000,748,0);   -- Gold Beastcoin (St
 -- ZoneID: 115 - Yagudo Acolyte
 -- ZoneID: 116 - Yagudo Acolyte
 INSERT INTO `mob_droplist` VALUES (2692,0,0,1000,841,470);      -- Yagudo Feather (47.0%)
-INSERT INTO `mob_droplist` VALUES (2692,0,0,1000,498,400);      -- Yagudo Bead Necklace (40.0%)
+INSERT INTO `mob_droplist` VALUES (2692,0,0,1000,498,150);      -- Yagudo Bead Necklace (15.0%)
 INSERT INTO `mob_droplist` VALUES (2692,0,0,1000,841,@VCOMMON); -- Yagudo Feather (Very Common, 24%)
 INSERT INTO `mob_droplist` VALUES (2692,0,0,1000,4666,180);     -- Scroll Of Paralyze (18.0%)
 INSERT INTO `mob_droplist` VALUES (2692,0,0,1000,841,160);      -- Yagudo Feather (16.0%)
@@ -22415,7 +22415,7 @@ INSERT INTO `mob_droplist` VALUES (2693,0,0,1000,4745,@VRARE); -- Scroll Of Snea
 INSERT INTO `mob_droplist` VALUES (2693,2,0,1000,656,0);       -- Beastcoin (Steal)
 
 -- ZoneID: 145 - Yagudo Acolyte
-INSERT INTO `mob_droplist` VALUES (2694,0,0,1000,498,330);     -- Yagudo Bead Necklace (33.0%)
+INSERT INTO `mob_droplist` VALUES (2694,0,0,1000,498,150);     -- Yagudo Bead Necklace (15.0%)
 INSERT INTO `mob_droplist` VALUES (2694,0,0,1000,4666,60);     -- Scroll Of Paralyze (6.0%)
 INSERT INTO `mob_droplist` VALUES (2694,0,0,1000,12984,@RARE); -- Ash Clogs (Rare, 5%)
 INSERT INTO `mob_droplist` VALUES (2694,0,0,1000,4680,40);     -- Scroll Of Barsleep (4.0%)
@@ -22616,7 +22616,7 @@ INSERT INTO `mob_droplist` VALUES (2716,0,0,1000,841,1130);       -- Yagudo Feat
 INSERT INTO `mob_droplist` VALUES (2716,0,0,1000,841,560);        -- Yagudo Feather (56.0%)
 INSERT INTO `mob_droplist` VALUES (2716,0,0,1000,841,380);        -- Yagudo Feather (38.0%)
 INSERT INTO `mob_droplist` VALUES (2716,0,0,1000,841,280);        -- Yagudo Feather (28.0%)
-INSERT INTO `mob_droplist` VALUES (2716,0,0,1000,498,@VCOMMON);   -- Yagudo Bead Necklace (Very Common, 24%)
+INSERT INTO `mob_droplist` VALUES (2716,0,0,1000,498,150);   -- Yagudo Bead Necklace (15.0%)
 INSERT INTO `mob_droplist` VALUES (2716,0,0,1000,1981,@UNCOMMON); -- Skull Locust (Uncommon, 10%)
 INSERT INTO `mob_droplist` VALUES (2716,2,0,1000,656,0);          -- Beastcoin (Steal)
 
@@ -22630,7 +22630,7 @@ INSERT INTO `mob_droplist` VALUES (2717,2,0,1000,656,0);          -- Beastcoin (
 INSERT INTO `mob_droplist` VALUES (2717,4,0,1000,4537,0);         -- Roast Carp (Despoil)
 
 -- ZoneID: 145 - Yagudo Initiate
-INSERT INTO `mob_droplist` VALUES (2718,0,0,1000,498,220);      -- Yagudo Bead Necklace (22.0%)
+INSERT INTO `mob_droplist` VALUES (2718,0,0,1000,498,150);      -- Yagudo Bead Necklace (15.0%)
 INSERT INTO `mob_droplist` VALUES (2718,0,0,1000,12448,@VRARE); -- Bronze Cap (Very Rare, 1%)
 INSERT INTO `mob_droplist` VALUES (2718,0,0,1000,12704,@VRARE); -- Bronze Mittens (Very Rare, 1%)
 INSERT INTO `mob_droplist` VALUES (2718,0,0,1000,12832,@VRARE); -- Bronze Subligar (Very Rare, 1%)
@@ -22741,7 +22741,7 @@ INSERT INTO `mob_droplist` VALUES (2732,0,0,1000,12992,@VRARE);   -- Solea (Very
 INSERT INTO `mob_droplist` VALUES (2732,2,0,1000,656,0);          -- Beastcoin (Steal)
 
 -- ZoneID: 145 - Yagudo Mendicant
-INSERT INTO `mob_droplist` VALUES (2733,0,0,1000,498,270);      -- Yagudo Bead Necklace (27.0%)
+INSERT INTO `mob_droplist` VALUES (2733,0,0,1000,498,150);      -- Yagudo Bead Necklace (15.0%)
 INSERT INTO `mob_droplist` VALUES (2733,0,0,1000,750,140);      -- Silver Beastcoin (14.0%)
 INSERT INTO `mob_droplist` VALUES (2733,0,0,1000,2759,40);      -- Block Of Yagudo Caulk (4.0%)
 INSERT INTO `mob_droplist` VALUES (2733,0,0,1000,12736,20);     -- Mitts (2.0%)
@@ -22800,7 +22800,7 @@ INSERT INTO `mob_droplist` VALUES (2740,2,0,1000,656,0);          -- Beastcoin (
 
 -- ZoneID:  95 - Yagudo Persecutor
 -- ZoneID: 145 - Yagudo Persecutor
-INSERT INTO `mob_droplist` VALUES (2741,0,0,1000,498,230);     -- Yagudo Bead Necklace (23.0%)
+INSERT INTO `mob_droplist` VALUES (2741,0,0,1000,498,150);     -- Yagudo Bead Necklace (15.0%)
 INSERT INTO `mob_droplist` VALUES (2741,0,0,1000,750,@COMMON); -- Silver Beastcoin (Common, 15%)
 INSERT INTO `mob_droplist` VALUES (2741,0,0,1000,2759,80);     -- Block Of Yagudo Caulk (8.0%)
 INSERT INTO `mob_droplist` VALUES (2741,0,0,1000,12456,20);    -- Hachimaki (2.0%)
@@ -22841,7 +22841,7 @@ INSERT INTO `mob_droplist` VALUES (2744,0,0,1000,12472,@VRARE);   -- Circlet (Ve
 INSERT INTO `mob_droplist` VALUES (2744,2,0,1000,656,0);          -- Beastcoin (Steal)
 
 -- ZoneID: 145 - Yagudo Piper
-INSERT INTO `mob_droplist` VALUES (2745,0,0,1000,498,280);        -- Yagudo Bead Necklace (28.0%)
+INSERT INTO `mob_droplist` VALUES (2745,0,0,1000,498,150);        -- Yagudo Bead Necklace (15.0%)
 INSERT INTO `mob_droplist` VALUES (2745,0,0,1000,5071,@UNCOMMON); -- Scroll Of Foe Lullaby (Uncommon, 10%)
 INSERT INTO `mob_droplist` VALUES (2745,0,0,1000,4994,70);        -- Scroll Of Mages Ballad (7.0%)
 INSERT INTO `mob_droplist` VALUES (2745,0,0,1000,2759,30);        -- Block Of Yagudo Caulk (3.0%)
@@ -22922,7 +22922,7 @@ INSERT INTO `mob_droplist` VALUES (2750,0,0,1000,4745,@VRARE); -- Scroll Of Snea
 INSERT INTO `mob_droplist` VALUES (2750,2,0,1000,750,0);       -- Silver Beastcoin (Steal)
 
 -- ZoneID: 145 - Yagudo Priest
-INSERT INTO `mob_droplist` VALUES (2751,0,0,1000,498,350);        -- Yagudo Bead Necklace (35.0%)
+INSERT INTO `mob_droplist` VALUES (2751,0,0,1000,498,150);        -- Yagudo Bead Necklace (15.0%)
 INSERT INTO `mob_droplist` VALUES (2751,0,0,1000,1026,110);       -- Giddeus Chest Key (11.0%)
 INSERT INTO `mob_droplist` VALUES (2751,0,0,1000,2759,@UNCOMMON); -- Block Of Yagudo Caulk (Uncommon, 10%)
 INSERT INTO `mob_droplist` VALUES (2751,0,0,1000,4667,80);        -- Scroll Of Silence (8.0%)
@@ -23012,7 +23012,7 @@ INSERT INTO `mob_droplist` VALUES (2760,2,0,1000,748,0);   -- Gold Beastcoin (St
 
 -- ZoneID: 115 - Yagudo Scribe
 -- ZoneID: 116 - Yagudo Scribe
-INSERT INTO `mob_droplist` VALUES (2761,0,0,1000,498,360);    -- Yagudo Bead Necklace (36.0%)
+INSERT INTO `mob_droplist` VALUES (2761,0,0,1000,498,150);    -- Yagudo Bead Necklace (15.0%)
 INSERT INTO `mob_droplist` VALUES (2761,0,0,1000,4862,60);    -- Scroll Of Blind (6.0%)
 INSERT INTO `mob_droplist` VALUES (2761,0,0,1000,4866,@RARE); -- Scroll Of Bind (Rare, 5%)
 INSERT INTO `mob_droplist` VALUES (2761,0,0,1000,841,20);     -- Yagudo Feather (2.0%)
@@ -23030,7 +23030,7 @@ INSERT INTO `mob_droplist` VALUES (2762,0,0,1000,841,@VRARE); -- Yagudo Feather 
 INSERT INTO `mob_droplist` VALUES (2762,2,0,1000,656,0);      -- Beastcoin (Steal)
 
 -- ZoneID: 145 - Yagudo Scribe
-INSERT INTO `mob_droplist` VALUES (2763,0,0,1000,498,260);      -- Yagudo Bead Necklace (26.0%)
+INSERT INTO `mob_droplist` VALUES (2763,0,0,1000,498,150);      -- Yagudo Bead Necklace (15.0%)
 INSERT INTO `mob_droplist` VALUES (2763,0,0,1000,4862,110);     -- Scroll Of Blind (11.0%)
 INSERT INTO `mob_droplist` VALUES (2763,0,0,1000,4866,60);      -- Scroll Of Bind (6.0%)
 INSERT INTO `mob_droplist` VALUES (2763,0,0,1000,12728,30);     -- Cuffs (3.0%)

--- a/sql/mob_groups.sql
+++ b/sql/mob_groups.sql
@@ -10558,7 +10558,7 @@ INSERT INTO `mob_groups` VALUES (15,3912,153,'Thunder_Elemental',960,4,2410,0,0,
 INSERT INTO `mob_groups` VALUES (16,4103,153,'Unut',0,32,2524,6300,0,72,72,0);
 INSERT INTO `mob_groups` VALUES (17,2745,153,'Morbol_Menace',960,0,1738,0,0,67,70,0);
 INSERT INTO `mob_groups` VALUES (18,1191,153,'Elder_Goobbue',960,0,3012,0,0,74,77,0);
-INSERT INTO `mob_groups` VALUES (19,2282,153,'Korrigan',960,0,343,0,0,72,75,0);
+INSERT INTO `mob_groups` VALUES (19,2282,153,'Korrigan',960,0,3228,0,0,72,75,0);
 INSERT INTO `mob_groups` VALUES (20,3649,153,'Skimmer',960,0,142,0,0,72,74,0);
 INSERT INTO `mob_groups` VALUES (21,3768,153,'Steelshell',960,0,2330,0,0,73,76,0);
 INSERT INTO `mob_groups` VALUES (22,3200,153,'Processionaire',960,0,2022,0,0,72,75,0);


### PR DESCRIPTION
I affirm:
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x ] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [ ] I've tested my code and the things my code has changed since the last commit in the PR, and will test after any later commits

## What does this pull request do?
Fixes the drop percentage of Kraken Club as it currently drops with the percentage of an Octave Club. 
It Fixes the Korrigan Drops as it is currently like a Leech. There was no droplist for the Korrigan, So I created a fresh new one with the drops and despoil including a new droplist that I attached in the Mob groupings. 

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
