### PR TITLE
18% Movement CAP

### DIFF
--- a/sql/item_mods.sql
+++ b/sql/item_mods.sql
@@ -53975,7 +53975,7 @@ INSERT INTO `item_mods` VALUES (25718,384,400); -- HASTE_GEAR: 400
 INSERT INTO `item_mods` VALUES (25722,1,1);     -- DEF: 1
 
 -- Kupo Suit
-INSERT INTO `item_mods` VALUES (25726,169,18);  -- MOVE: +18%
+INSERT INTO `item_mods` VALUES (25726,169,19);  -- MOVE: +18%
 INSERT INTO `item_mods` VALUES (25726,1,1);     -- DEF: 1
 
 -- Meghanada Cuirie

--- a/src/map/entities/battleentity.cpp
+++ b/src/map/entities/battleentity.cpp
@@ -235,6 +235,10 @@ uint8 CBattleEntity::GetSpeed()
     float modifiedSpeed = static_cast<float>(startingSpeed) * modAmount;
     uint8 outputSpeed   = static_cast<uint8>(modifiedSpeed);
 
+    if (static_cast<float>(getMod(Mod::MOVE)) > 19 && isMounted() == false)
+    {
+        return std::clamp<uint8>(outputSpeed, std::numeric_limits<uint8>::min(), 59);
+    }
     return std::clamp<uint8>(outputSpeed, std::numeric_limits<uint8>::min(), std::numeric_limits<uint8>::max());
 }
 


### PR DESCRIPTION
This will require a rebuild as this change to the battleentity.cpp will HARD CAP MOVEMENT SPEED TO 18% with Modifiers.

Updated Kupo suit also because I am dumb +1

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
