### PR TITLE
Correct time check equalities

### DIFF
--- a/scripts/zones/Northern_San_dOria/npcs/Mulaujeant.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Mulaujeant.lua
@@ -20,9 +20,9 @@ entity.onTrigger = function(player, npc)
 
     if missionaryManVar == 2 then
         player:startEvent(698, 0, 1146) -- Start statue creation
-    elseif missionaryManVar == 3 and finishtime < os.time() then
+    elseif missionaryManVar == 3 and finishtime > os.time() then
         player:startEvent(699) -- During statue creation
-    elseif missionaryManVar == 3 and finishtime >= os.time() then
+    elseif missionaryManVar == 3 and finishtime <= os.time() then
         player:startEvent(700) -- End of statue creation
     elseif missionaryManVar == 4 then
         player:startEvent(701) -- During quest (after creation)


### PR DESCRIPTION
It appears the time check greater than and less than signs were flipped in this script. This code will be a bandaid until moved into the interactions portion of LSB.

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

Fix time checks

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
