### PR TITLE
Moved drops from Crawlers Nest into a module

### DIFF
--- a/modules/catseyexi/sql/Crawlers_Nest_drop_list_changes.sql
+++ b/modules/catseyexi/sql/Crawlers_Nest_drop_list_changes.sql
@@ -1,0 +1,48 @@
+-- ZoneID: 197 - Blazer Beetle
+DELETE FROM mob_droplist WHERE dropId = "292";
+INSERT INTO `mob_droplist` VALUES (292,0,0,1000,846,1000);    -- Insect Wing (Always, 100%)
+INSERT INTO `mob_droplist` VALUES (292,0,0,1000,889,620);        -- Beetle Shell (62.0%)
+INSERT INTO `mob_droplist` VALUES (292,0,0,1000,894,480);        -- Beetle Jaw (48.0%)
+-- INSERT INTO `mob_droplist` VALUES (292,0,0,1000,889,420);        -- Beetle Shell (42.0%)
+INSERT INTO `mob_droplist` VALUES (292,0,0,1000,1040,100); -- Nest Chest Key (Uncommon, 10%)
+INSERT INTO `mob_droplist` VALUES (292,4,0,1000,846,0);          -- Insect Wing (Despoil)
+
+-- ZoneID: 197 - Helm Beetle
+DELETE FROM mob_droplist WHERE dropId = "1298";
+INSERT INTO `mob_droplist` VALUES (1298,0,0,1000,846,920);    -- Insect Wing (92.0%)
+INSERT INTO `mob_droplist` VALUES (1298,0,0,1000,889,620);    -- Beetle Shell (62.0%)
+INSERT INTO `mob_droplist` VALUES (1298,0,0,1000,894,370);    -- Beetle Jaw (37.0%)
+-- INSERT INTO `mob_droplist` VALUES (1298,0,0,1000,889,360);    -- Beetle Shell (36.0%)
+INSERT INTO `mob_droplist` VALUES (1298,0,0,1000,1045,50); -- Nest Coffer Key (Rare, 5%)
+INSERT INTO `mob_droplist` VALUES (1298,4,0,1000,846,0);      -- Insect Wing (Despoil)
+
+-- ZoneID: 197 - Labyrinth Lizard
+DELETE FROM mob_droplist WHERE dropId = "1474";
+INSERT INTO `mob_droplist` VALUES (1474,0,0,1000,4362,1860);    -- Lizard Egg (186.0%)
+INSERT INTO `mob_droplist` VALUES (1474,0,0,1000,852,620);      -- Lizard Skin (62.0%)
+INSERT INTO `mob_droplist` VALUES (1474,0,0,1000,4362,930);     -- Lizard Egg (93.0%)
+INSERT INTO `mob_droplist` VALUES (1474,0,0,1000,926,900);      -- Lizard Tail (90.0%)
+INSERT INTO `mob_droplist` VALUES (1474,0,0,1000,4362,620);     -- Lizard Egg (62.0%)
+-- INSERT INTO `mob_droplist` VALUES (1474,0,0,1000,852,480);      -- Lizard Skin (48.0%)
+-- INSERT INTO `mob_droplist` VALUES (1474,0,0,1000,4362,460);     -- Lizard Egg (46.0%)
+-- INSERT INTO `mob_droplist` VALUES (1474,0,0,1000,4362,370);     -- Lizard Egg (37.0%)
+-- INSERT INTO `mob_droplist` VALUES (1474,0,0,1000,852,320);      -- Lizard Skin (32.0%)
+-- INSERT INTO `mob_droplist` VALUES (1474,0,0,1000,4362,310);     -- Lizard Egg (31.0%)
+-- INSERT INTO `mob_droplist` VALUES (1474,0,0,1000,852,240); -- Lizard Skin (Very Common, 24%)
+-- INSERT INTO `mob_droplist` VALUES (1474,0,0,1000,852,190);      -- Lizard Skin (19.0%)
+INSERT INTO `mob_droplist` VALUES (1474,0,0,1000,1040,90);      -- Nest Chest Key (9.0%)
+INSERT INTO `mob_droplist` VALUES (1474,4,0,1000,926,0);        -- Lizard Tail (Despoil)
+INSERT INTO `mob_droplist` VALUES (1474,2,0,1000,4362,0);       -- Lizard Egg (Steal)
+INSERT INTO `mob_droplist` VALUES (1474,4,0,1000,4362,0);       -- Lizard Egg (Despoil)
+
+-- ZoneID: 197 - Maze Lizard
+DELETE FROM mob_droplist WHERE dropId = "1645";
+INSERT INTO `mob_droplist` VALUES (1645,0,0,1000,4362,1250);   -- Lizard Egg (125.0%)
+INSERT INTO `mob_droplist` VALUES (1645,0,0,1000,926,1000); -- Lizard Tail (Always, 100%)
+INSERT INTO `mob_droplist` VALUES (1645,0,0,1000,4362,620);    -- Lizard Egg (62.0%)
+INSERT INTO `mob_droplist` VALUES (1645,0,0,1000,852,570);     -- Lizard Skin (57.0%)
+-- INSERT INTO `mob_droplist` VALUES (1645,0,0,1000,4362,420);    -- Lizard Egg (42.0%)
+-- INSERT INTO `mob_droplist` VALUES (1645,0,0,1000,4362,310);    -- Lizard Egg (31.0%)
+-- INSERT INTO `mob_droplist` VALUES (1645,0,0,1000,852,290);     -- Lizard Skin (29.0%)
+-- INSERT INTO `mob_droplist` VALUES (1645,0,0,1000,852,190);     -- Lizard Skin (19.0%)
+INSERT INTO `mob_droplist` VALUES (1645,2,0,1000,4362,0);      -- Lizard Egg (Steal)


### PR DESCRIPTION
fixed the drop rate of lizard skins and beetle shells in Crawlers Nest
