### PR TITLE
Mining probabilities update

### DIFF
--- a/scripts/globals/helm.lua
+++ b/scripts/globals/helm.lua
@@ -1027,20 +1027,28 @@ local helmInfo =
             {
                 drops =
                 {
-                    { 2250, 1108 }, -- Sulfur
+                    { 2100, 1108 }, -- Sulfur
                     { 2990,  643 }, -- Iron Ore
                     { 1590, 1155 }, -- Iron Sand
                     { 1540,  768 }, -- Flint Stone
                     { 1340,  928 }, -- Bomb Ash
                     {  960, 1632 }, -- Moblin Mail
-                    { 1150, 1625 }, -- Moblin Helm
+                    { 1000, 1625 }, -- Moblin Helm
                     {  450, 1631 }, -- Moblin Armor
                     {  380, 2160 }, -- Troll Pauldron
                     {  450, 2161 }, -- Troll Vambrace
                     {  430, 1638 }, -- Moblin Mask
                     {  210,  902 }, -- Demon Horn
-                    {  140,  646 }, -- Adaman Ore
-                    {   30,  685 }, -- Khroma Ore
+                    {  400,  646 }, -- Adaman Ore
+                    {   400,  685 }, -- Khroma Ore
+                    {   500,  1255 }, -- Fire Ore
+                    {   500,  1256 }, -- Ice Ore
+                    {   500,  1257 }, -- Wind Ore
+                    {   500,  1258 }, -- Earth Ore
+                    {   500,  1258 }, -- Lightning Ore
+                    {   500,  1260 }, -- Water Ore
+                    {   500,  1261 }, -- Light Ore
+                    {   500,  1262 }, -- Dark Ore
                 },
 
                 points =
@@ -1079,15 +1087,25 @@ local helmInfo =
                     { 1720,  768 }, -- Flint Stone
                     {  290,  737 }, -- Gold Ore
                     { 1440, 1155 }, -- Iron Sand
-                    {   50, 2228 }, -- Luminium Ore
+                    {  400, 2228 }, -- Luminium Ore
                     {  430, 1631 }, -- Moblin Armor
                     {  430, 1625 }, -- Moblin Helm
                     {  480, 1632 }, -- Moblin Mail
                     {  290, 1638 }, -- Moblin Mask
-                    {  100,  739 }, -- Orichalcum Ore
+                    {  300,  739 }, -- Orichalcum Ore
                     { 1200, 1108 }, -- Pinch of Sulfur
                     {  480, 2160 }, -- Troll Pauldron
                     {  330, 2161 }, -- Troll Vambrace
+                    {   250,  685 }, -- Khroma Ore
+                    {   500,  1255 }, -- Fire Ore
+                    {   500,  1256 }, -- Ice Ore
+                    {   500,  1257 }, -- Wind Ore
+                    {   500,  1258 }, -- Earth Ore
+                    {   500,  1258 }, -- Lightning Ore
+                    {   500,  1260 }, -- Water Ore
+                    {   500,  1261 }, -- Light Ore
+                    {   500,  1262 }, -- Dark Ore
+
                 },
 
                 points =
@@ -1347,17 +1365,26 @@ local helmInfo =
             {
                 drops =
                 {
-                    { 3260,   768 }, -- Flint Stone
-                    { 1520,   643 }, -- Iron Ore
-                    {  430,  1108 }, -- Sulfur
+                    {  3260,   768 }, -- Flint Stone
+                    {  1520,   643 }, -- Iron Ore
+                    {  600,  1108 }, -- Sulfur
                     {  650, 17316 }, -- Bomb Arm
                     {  870,   928 }, -- Bomb Ash
-                    { 1300,  1155 }, -- Iron Sand
-                    {  250,   646 }, -- Adaman Ore
+                    {  1300,  1155 }, -- Iron Sand
+                    {  400,   646 }, -- Adaman Ore
                     {  600,   645 }, -- Darksteel Ore
-                    { 1520,  2126 }, -- Orpiment
-                    {  100,   739 }, -- Orichalcum Ore
-                    {  220,   769 }, -- Colored Rock
+                    {  1520,  2126 }, -- Orpiment
+                    {   300,   739 }, -- Orichalcum Ore
+                    {   600,   769 }, -- Colored Rock
+                    {   325,  685 }, -- Khroma Ore
+                    {   500,  1255 }, -- Fire Ore
+                    {   500,  1256 }, -- Ice Ore
+                    {   500,  1257 }, -- Wind Ore
+                    {   500,  1258 }, -- Earth Ore
+                    {   500,  1258 }, -- Lightning Ore
+                    {   500,  1260 }, -- Water Ore
+                    {   500,  1261 }, -- Light Ore
+                    {   500,  1262 }, -- Dark Ore
                 },
 
                 points =

--- a/scripts/globals/helm.lua
+++ b/scripts/globals/helm.lua
@@ -966,10 +966,18 @@ local helmInfo =
                     {  600, 1638 }, -- Moblin Mask
                     {  570,  568 }, -- Goblin Die
                     {  570, 1631 }, -- Moblin Armor
-                    {   80,  645 }, -- Darksteel Ore
-                    {   80,  644 }, -- Mythril Ore
-                    {   70,  737 }, -- Gold Ore
-                    {   70,  738 }, -- Platium Ore
+                    {  150,  645 }, -- Darksteel Ore
+                    {  400,  644 }, -- Mythril Ore
+                    {  300,  737 }, -- Gold Ore
+                    {  200,  738 }, -- Platium Ore
+                    {  100,  1255 }, -- Fire Ore
+                    {  100,  1256 }, -- Ice Ore
+                    {  100,  1257 }, -- Wind Ore
+                    {  100,  1258 }, -- Earth Ore
+                    {  100,  1258 }, -- Lightning Ore
+                    {  100,  1260 }, -- Water Ore
+                    {  100,  1261 }, -- Light Ore
+                    {  100,  1262 }, -- Dark Ore
                 },
 
                 points =
@@ -994,18 +1002,26 @@ local helmInfo =
             {
                 drops =
                 {
-                    { 1660,  640 }, -- Copper Ore
-                    { 1100,  641 }, -- Tin Ore
-                    { 1450,  642 }, -- Zinc Ore
+                    { 1660, 640 }, -- Copper Ore
+                    { 1100, 641 }, -- Tin Ore
+                    { 1450, 642 }, -- Zinc Ore
                     { 1790, 1654 }, -- Igneous Rock
-                    { 1450,  736 }, -- Silver Ore
-                    {  140,  678 }, -- Aluminum Ore
-                    { 1720,  643 }, -- Iron Ore
-                    {   70,  645 }, -- Darksteel Ore
-                    {  210,  644 }, -- Mythril Ore
-                    {  140,  737 }, -- Gold Ore
-                    {  340,  738 }, -- Platium Ore
-                    {   70,  769 }, -- Colored Rock
+                    { 1450, 736 }, -- Silver Ore
+                    { 240, 678 }, -- Aluminum Ore
+                    { 1720, 643 }, -- Iron Ore
+                    { 150, 645 }, -- Darksteel Ore
+                    { 440, 644 }, -- Mythril Ore
+                    { 240, 737 }, -- Gold Ore
+                    { 340, 738 }, -- Platium Ore
+                    { 100, 769 }, -- Colored Rock
+                    { 100, 1255 }, -- Fire Ore
+                    { 100, 1256 }, -- Ice Ore
+                    { 100, 1257 }, -- Wind Ore
+                    { 100, 1258 }, -- Earth Ore
+                    { 100, 1258 }, -- Lightning Ore
+                    { 100, 1260 }, -- Water Ore
+                    { 100, 1261 }, -- Light Ore
+                    { 100, 1262 }, -- Dark Ore
                 },
 
                 points =
@@ -1038,17 +1054,17 @@ local helmInfo =
                     {  380, 2160 }, -- Troll Pauldron
                     {  450, 2161 }, -- Troll Vambrace
                     {  430, 1638 }, -- Moblin Mask
-                    {  210,  902 }, -- Demon Horn
+                    {  400,  902 }, -- Demon Horn
                     {  400,  646 }, -- Adaman Ore
-                    {   400,  685 }, -- Khroma Ore
-                    {   500,  1255 }, -- Fire Ore
-                    {   500,  1256 }, -- Ice Ore
-                    {   500,  1257 }, -- Wind Ore
-                    {   500,  1258 }, -- Earth Ore
-                    {   500,  1258 }, -- Lightning Ore
-                    {   500,  1260 }, -- Water Ore
-                    {   500,  1261 }, -- Light Ore
-                    {   500,  1262 }, -- Dark Ore
+                    {  400,  685 }, -- Khroma Ore
+                    {  500,  1255 }, -- Fire Ore
+                    {  500,  1256 }, -- Ice Ore
+                    {  500,  1257 }, -- Wind Ore
+                    {  500,  1258 }, -- Earth Ore
+                    {  500,  1258 }, -- Lightning Ore
+                    {  500,  1260 }, -- Water Ore
+                    {  500,  1261 }, -- Light Ore
+                    {  500,  1262 }, -- Dark Ore
                 },
 
                 points =
@@ -1096,15 +1112,15 @@ local helmInfo =
                     { 1200, 1108 }, -- Pinch of Sulfur
                     {  480, 2160 }, -- Troll Pauldron
                     {  330, 2161 }, -- Troll Vambrace
-                    {   250,  685 }, -- Khroma Ore
-                    {   500,  1255 }, -- Fire Ore
-                    {   500,  1256 }, -- Ice Ore
-                    {   500,  1257 }, -- Wind Ore
-                    {   500,  1258 }, -- Earth Ore
-                    {   500,  1258 }, -- Lightning Ore
-                    {   500,  1260 }, -- Water Ore
-                    {   500,  1261 }, -- Light Ore
-                    {   500,  1262 }, -- Dark Ore
+                    {  250,  685 }, -- Khroma Ore
+                    {  500,  1255 }, -- Fire Ore
+                    {  500,  1256 }, -- Ice Ore
+                    {  500,  1257 }, -- Wind Ore
+                    {  500,  1258 }, -- Earth Ore
+                    {  500,  1258 }, -- Lightning Ore
+                    {  500,  1260 }, -- Water Ore
+                    {  500,  1261 }, -- Light Ore
+                    {  500,  1262 }, -- Dark Ore
 
                 },
 
@@ -1137,25 +1153,33 @@ local helmInfo =
             {
                 drops =
                 {
-                    { 1870,   640 }, -- Copper Ore
-                    { 1930,   642 }, -- Zinc Ore
-                    { 1500,   641 }, -- Tin Ore
+                    { 1870, 640 }, -- Copper Ore
+                    { 1930, 642 }, -- Zinc Ore
+                    { 1500, 641 }, -- Tin Ore
                     { 1340, 17296 }, -- Pebble
-                    {  860,   736 }, -- Silver Ore
-                    { 1180,   643 }, -- Iron Ore
-                    {  750,   644 }, -- Mythril Ore
-                    {  210,  1638 }, -- Moblin Mask
-                    {  110,  1625 }, -- Moblin Helm
-                    {  110,  1632 }, -- Moblin Mail
-                    {   50,  1631 }, -- Moblin Armor
-                    {  160,   738 }, -- Platium Ore
+                    { 860, 736 }, -- Silver Ore
+                    { 1180, 643 }, -- Iron Ore
+                    { 750, 644 }, -- Mythril Ore
+                    { 210, 1638 }, -- Moblin Mask
+                    { 110, 1625 }, -- Moblin Helm
+                    { 110, 1632 }, -- Moblin Mail
+                    { 50, 1631 }, -- Moblin Armor
+                    { 160, 738 }, -- Platium Ore
+                    { 100, 1255 }, -- Fire Ore
+                    { 100, 1256 }, -- Ice Ore
+                    { 100, 1257 }, -- Wind Ore
+                    { 100, 1258 }, -- Earth Ore
+                    { 100, 1258 }, -- Lightning Ore
+                    { 100, 1260 }, -- Water Ore
+                    { 100, 1261 }, -- Light Ore
+                    { 100, 1262 }, -- Dark Ore
                 },
 
                 points =
                 {
                     { -252.577,  38.568,  329.700 },
                     { -234.388,  38.007,  285.331 },
-                    { -233.113,  38.287,  315.211 }, -- (R)E-8
+                    { -233.113,  38.287,  315.211 }, -- (R)E-8 
                     { -232.485,  38.922,  398.626 },
                     {  142.096,  -8.326,  345.036 }, -- (R)I-8
                     {  157.439, -20.374,  354.538 },
@@ -1196,9 +1220,17 @@ local helmInfo =
                     { 1320,   642 }, -- Zinc Ore
                     {  840,   768 }, -- Flint Stone
                     {  360,   736 }, -- Silver Ore
-                    {  170,   769 }, -- Colored Rock
+                    {  100,   769 }, -- Colored Rock
                     {  150,   645 }, -- Darksteel Ore
-                    {  110,   737 }, -- Gold Ore
+                    {  200,   737 }, -- Gold Ore
+                    {  100,  1255 }, -- Fire Ore
+                    {  100,  1256 }, -- Ice Ore
+                    {  100,  1257 }, -- Wind Ore
+                    {  100,  1258 }, -- Earth Ore
+                    {  100,  1258 }, -- Lightning Ore
+                    {  100,  1260 }, -- Water Ore
+                    {  100,  1261 }, -- Light Ore
+                    {  100,  1262 }, -- Dark Ore
                 },
 
                 points =
@@ -1252,6 +1284,14 @@ local helmInfo =
                     {  900,   736 }, -- Silver Ore
                     {  800,   640 }, -- Copper Ore
                     {  100,   738 }, -- Platium Ore
+                    {  100,  1255 }, -- Fire Ore
+                    {  100,  1256 }, -- Ice Ore
+                    {  100,  1257 }, -- Wind Ore
+                    {  100,  1258 }, -- Earth Ore
+                    {  100,  1258 }, -- Lightning Ore
+                    {  100,  1260 }, -- Water Ore
+                    {  100,  1261 }, -- Light Ore
+                    {  100,  1262 }, -- Dark Ore
                 },
 
                 points =
@@ -1289,9 +1329,17 @@ local helmInfo =
                     { 1850,   640 }, -- Copper Ore
                     { 1330,   642 }, -- Zinc Ore
                     { 1120,   641 }, -- Tin Ore
-                    {  550,  1984 }, -- Snapping Mole
-                    {  180,   736 }, -- Silver Ore
-                    {   40,   645 }, -- Darksteel Ore
+                    { 550,  1984 }, -- Snapping Mole
+                    { 180,   736 }, -- Silver Ore
+                    { 100,   645 }, -- Darksteel Ore
+                    { 100,  1255 }, -- Fire Ore
+                    { 100,  1256 }, -- Ice Ore
+                    { 100,  1257 }, -- Wind Ore
+                    { 100,  1258 }, -- Earth Ore
+                    { 100,  1258 }, -- Lightning Ore
+                    { 100,  1260 }, -- Water Ore
+                    { 100,  1261 }, -- Light Ore
+                    { 100,  1262 }, -- Dark Ore
                 },
 
                 points =
@@ -1335,7 +1383,15 @@ local helmInfo =
                     {  810,   736 }, -- Silver Ore
                     {  590,   645 }, -- Darksteel Ore
                     {  400,   769 }, -- Colored Rock
-                    {   80,   737 }, -- Gold Ore
+                    {  300,   737 }, -- Gold Ore
+                    {  100,  1255 }, -- Fire Ore
+                    {  100,  1256 }, -- Ice Ore
+                    {  100,  1257 }, -- Wind Ore
+                    {  100,  1258 }, -- Earth Ore
+                    {  100,  1258 }, -- Lightning Ore
+                    {  100,  1260 }, -- Water Ore
+                    {  100,  1261 }, -- Light Ore
+                    {  100,  1262 }, -- Dark Ore
                 },
 
                 points =
@@ -1365,26 +1421,26 @@ local helmInfo =
             {
                 drops =
                 {
-                    {  3260,   768 }, -- Flint Stone
-                    {  1520,   643 }, -- Iron Ore
-                    {  600,  1108 }, -- Sulfur
+                    {  3260, 768 }, -- Flint Stone
+                    {  1520, 643 }, -- Iron Ore
+                    {  600, 1108 }, -- Sulfur
                     {  650, 17316 }, -- Bomb Arm
-                    {  870,   928 }, -- Bomb Ash
-                    {  1300,  1155 }, -- Iron Sand
-                    {  400,   646 }, -- Adaman Ore
-                    {  600,   645 }, -- Darksteel Ore
-                    {  1520,  2126 }, -- Orpiment
-                    {   300,   739 }, -- Orichalcum Ore
-                    {   600,   769 }, -- Colored Rock
-                    {   325,  685 }, -- Khroma Ore
-                    {   500,  1255 }, -- Fire Ore
-                    {   500,  1256 }, -- Ice Ore
-                    {   500,  1257 }, -- Wind Ore
-                    {   500,  1258 }, -- Earth Ore
-                    {   500,  1258 }, -- Lightning Ore
-                    {   500,  1260 }, -- Water Ore
-                    {   500,  1261 }, -- Light Ore
-                    {   500,  1262 }, -- Dark Ore
+                    {  870, 928 }, -- Bomb Ash
+                    {  1300, 1155 }, -- Iron Sand
+                    {  400, 646 }, -- Adaman Ore
+                    {  600, 645 }, -- Darksteel Ore
+                    {  1520, 2126 }, -- Orpiment
+                    {   300, 739 }, -- Orichalcum Ore
+                    {   600, 769 }, -- Colored Rock
+                    {   325, 685 }, -- Khroma Ore
+                    {   500, 1255 }, -- Fire Ore
+                    {   500, 1256 }, -- Ice Ore
+                    {   500, 1257 }, -- Wind Ore
+                    {   500, 1258 }, -- Earth Ore
+                    {   500, 1258 }, -- Lightning Ore
+                    {   500, 1260 }, -- Water Ore
+                    {   500, 1261 }, -- Light Ore
+                    {   500, 1262 }, -- Dark Ore
                 },
 
                 points =


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

Updates mining probabilities for khroma ore, oricalcum ore, luminium ore, adaman ore, and elemental ores.

- Khroma Ore - adjusted from .22% to 1-2%. Now available in Halvung & Ifrit's Cauldron 
- Oricalcum Ore - adjusted weights to be between 1-2%
- Luminum Ore - Adjusted weights to be between 1-2%
- Adman Ore - Adjusted weight to be between 1-2%
- Elemental Ores - Adjusted weights depending on zone (1-3%). Higher chance in higher level zones. Added these back in because a recent pull request removed them.

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->

1. Grab pickaxe
2. mine
3. refer to spreadsheet sent to carver for math
4. I don't code lua so please double check syntax