### PR TITLE
fix some incorrect function calls to clear up CI check for formatting

### DIFF
--- a/scripts/zones/Abyssea-La_Theine/npcs/Dominion_Tactician.lua
+++ b/scripts/zones/Abyssea-La_Theine/npcs/Dominion_Tactician.lua
@@ -108,7 +108,7 @@ entity.onEventFinish = function(player, csid, option)
     if option > 256 and option < 2818 then
         if player:getCurrency("dominion_note") > price then
             if tempItem then
-                if player:addtempItem(itemId, 1) then
+                if player:addTempItem(itemId, 1) then
                     player:delCurrency("dominion_note", price)
                     player:messageSpecial(ID.text.ITEM_OBTAINED, itemId)
                 else

--- a/scripts/zones/Abyssea-La_Theine/npcs/Dominion_Tactician.lua
+++ b/scripts/zones/Abyssea-La_Theine/npcs/Dominion_Tactician.lua
@@ -11,7 +11,7 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    local DM = player:getDominionNotes()
+    local DM = player:getCurrency("dominion_note")
     local Trophies = 0 -- Max all Trophy = 4294967295 sort out its bit mask later.
     player:startEvent(120, DM, 0, 0, 0, 0, Trophies)
 end
@@ -106,7 +106,7 @@ entity.onEventFinish = function(player, csid, option)
     end
 
     if option > 256 and option < 2818 then
-        if player:getDominionNotes() > Price then
+        if player:getCurrency("dominion_note") > Price then
             if TempItem then
                 if player:addTempItem(ItemID, 1) then
                     player:delCurrency("dominion_note", Price)

--- a/scripts/zones/Abyssea-La_Theine/npcs/Dominion_Tactician.lua
+++ b/scripts/zones/Abyssea-La_Theine/npcs/Dominion_Tactician.lua
@@ -12,17 +12,17 @@ end
 
 entity.onTrigger = function(player, npc)
     local DM = player:getCurrency("dominion_note")
-    local Trophies = 0 -- Max all Trophy = 4294967295 sort out its bit mask later.
-    player:startEvent(120, DM, 0, 0, 0, 0, Trophies)
+    local trophies = 0 -- Max all Trophy = 4294967295 sort out its bit mask later.
+    player:startEvent(120, DM, 0, 0, 0, 0, trophies)
 end
 
 entity.onEventUpdate = function(player, csid, option)
 end
 
 entity.onEventFinish = function(player, csid, option)
-    local Price = 0
-    local TempItem = false
-    local ItemID = 0
+    local price = 0
+    local tempItem = false
+    local itemId = 0
     -- local aug1 = 0
     -- local aug2 = 0
     -- local aug3 = 0
@@ -38,88 +38,88 @@ entity.onEventFinish = function(player, csid, option)
 
     -- Spending Dominion Notes
     if option == 257 then -- Unkai Domaru
-        Price = 1500
-        ItemID = 12039
+        price = 1500
+        itemId = 12039
     elseif option == 258 then -- Petrify Screen
-        Price = 300
-        TempItem = true
-        ItemID = 5876
+        price = 300
+        tempItem = true
+        itemId = 5876
     elseif option == 259 then -- Augmented Yataghan
-        Price = 2500
-        ItemID = 16485
+        price = 2500
+        itemId = 16485
         -- Work out augment selection via math.random
         -- (see Lower Jeuno Tenshodo Coffer script)
     elseif option == 513 then -- Inga Ningi
-        Price = 1500
-        ItemID = 12040
+        price = 1500
+        itemId = 12040
     elseif option == 514 then -- Terror Screen
-        Price = 300
-        TempItem = true
-        ItemID = 5877
+        price = 300
+        tempItem = true
+        itemId = 5877
     elseif option == 515 then -- Augmented Doom Tabar
-        Price = 2500
-        ItemID = 16660
+        price = 2500
+        itemId = 16660
         -- Augment here
     elseif option == 769 then -- Lancer's Plackart
-        Price = 1500
-        ItemID = 12041
+        price = 1500
+        itemId = 12041
     elseif option == 770 then -- Amnesia Screen
-        Price = 300
-        TempItem = true
-        ItemID = 5878
+        price = 300
+        tempItem = true
+        itemId = 5878
     elseif option == 771 then -- Augmented Yukitsugu
-        Price = 2500
-        ItemID = 16971
+        price = 2500
+        itemId = 16971
         -- Augment here
     elseif option == 1025 then -- Caller's Doublet
-        Price = 1500
-        ItemID = 12042
+        price = 1500
+        itemId = 12042
     elseif option == 1026 then -- Doom Screen
-        Price = 300
-        TempItem = true
-        ItemID = 5879
+        price = 300
+        tempItem = true
+        itemId = 5879
     elseif option == 1281 then -- Mavi Mintan
-        Price = 1500
-        ItemID = 12043
+        price = 1500
+        itemId = 12043
     elseif option == 1282 then -- Poison Screen
-        Price = 300
-        TempItem = true
-        ItemID = 5880
+        price = 300
+        tempItem = true
+        itemId = 5880
     elseif option == 1537 then -- Navarch's Frac
-        Price = 1500
-        ItemID = 12044
+        price = 1500
+        itemId = 12044
     elseif option == 1793 then -- Cirque Farsetto
-        Price = 1500
-        ItemID = 12045
+        price = 1500
+        itemId = 12045
     elseif option == 2049 then -- Charis Casaque
-        Price = 1500
-        ItemID = 12046
+        price = 1500
+        itemId = 12046
     elseif option == 2305 then -- Savant's Gown
-        Price = 1500
-        ItemID = 12047
+        price = 1500
+        itemId = 12047
     elseif option == 2561 then -- Incredescent Shade
-        Price = 300
-        ItemID = 3295
+        price = 300
+        itemId = 3295
     elseif option == 2817 then -- Decredescent Shade
-        Price = 300
-        ItemID = 3296
+        price = 300
+        itemId = 3296
     end
 
     if option > 256 and option < 2818 then
-        if player:getCurrency("dominion_note") > Price then
-            if TempItem then
-                if player:addTempItem(ItemID, 1) then
-                    player:delCurrency("dominion_note", Price)
-                    player:messageSpecial(ID.text.ITEM_OBTAINED, ItemID)
+        if player:getCurrency("dominion_note") > price then
+            if tempItem then
+                if player:addtempItem(itemId, 1) then
+                    player:delCurrency("dominion_note", price)
+                    player:messageSpecial(ID.text.ITEM_OBTAINED, itemId)
                 else
-                    player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, ItemID)
+                    player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, itemId)
                 end
             else
-                if player:addItem(ItemID, 1, a1, v1, a2, v2, a3, v3, a4, v4) then
-                    player:delCurrency("dominion_note", Price)
-                    player:messageSpecial(ID.text.ITEM_OBTAINED, ItemID)
+                if player:addItem(itemId, 1, a1, v1, a2, v2, a3, v3, a4, v4) then
+                    player:delCurrency("dominion_note", price)
+                    player:messageSpecial(ID.text.ITEM_OBTAINED, itemId)
                 else
-                    player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, ItemID)
+                    player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, itemId)
                 end
             end
         end

--- a/scripts/zones/The_Eldieme_Necropolis_[S]/mobs/Tethra.lua
+++ b/scripts/zones/The_Eldieme_Necropolis_[S]/mobs/Tethra.lua
@@ -158,7 +158,7 @@ entity.onMobFight = function(mob, target)
     -- Job Ability Functions
     -- Retaliates With Instant Stone IV And Level Up If Targeted (https://ffxiclopedia.fandom.com/wiki/Tethra)
     -- Starts Level Up Sequence When Any Other Ability Is Used (https://ffxiclopedia.fandom.com/wiki/Tethra)
-    mob:addListener("PLAYER_ABILITY_USED", "TETHRA_PLAYER_ABILITY_USED", function(mobArg, player, ability, action, target)
+    mob:addListener("PLAYER_ABILITY_USED", "TETHRA_PLAYER_ABILITY_USED", function(mobArg, player, ability, action, targetArg)
         --Retaliate and Level Up
         if ability:getID() == (46) then
             mobArg:setLocalVar("TAbilityRetaliate", 1)
@@ -173,15 +173,15 @@ entity.onMobFight = function(mob, target)
     -- Magic Handling
     -- Mob Should Retaliate With Instant Cast Stone IV (https://ffxiclopedia.fandom.com/wiki/Tethra)
     -- Mob Should Have Little To No Enmity Control (https://ffxiclopedia.fandom.com/wiki/Tethra)
-    mob:addListener("MAGIC_TAKE", "TETHRA_MAGIC_TAKE", function(target, caster, spell)
+    mob:addListener("MAGIC_TAKE", "TETHRA_MAGIC_TAKE", function(targetArg, caster, spell)
         if
-            target:getAnimationSub() == 0 and
+            targetArg:getAnimationSub() == 0 and
             spell:tookEffect() and
             (caster:isPC() or caster:isPet())
         then
-            target:setLocalVar("TMagicRetaliate", 1)
-            target:addEnmity(caster, 1000, 1000)
-            target:setAnimationSub(1)
+            targetArg:setLocalVar("TMagicRetaliate", 1)
+            targetArg:addEnmity(caster, 1000, 1000)
+            targetArg:setAnimationSub(1)
         end
     end)
 
@@ -193,8 +193,8 @@ entity.onMobFight = function(mob, target)
         end
     end)
 
-    mob:addListener("WEAPONSKILL_TAKE", "TETHRA_WEAPONSKILL_TAKE", function(target, attacker, skillid, tp, action)
-        target:addEnmity(attacker, 1000, 1000)
+    mob:addListener("WEAPONSKILL_TAKE", "TETHRA_WEAPONSKILL_TAKE", function(targetArg, attacker, skillid, tp, action)
+        targetArg:addEnmity(attacker, 1000, 1000)
     end)
 
 end

--- a/scripts/zones/The_Eldieme_Necropolis_[S]/mobs/Tethra.lua
+++ b/scripts/zones/The_Eldieme_Necropolis_[S]/mobs/Tethra.lua
@@ -4,7 +4,7 @@
 ------------------------------
 mixins =
 {
-	require("scripts/mixins/fomor_hate"),
+    require("scripts/mixins/fomor_hate"),
     require("scripts/mixins/job_special"),
     require("scripts/mixins/rage")
 }
@@ -26,7 +26,7 @@ end
 
 entity.onMobSpawn = function(mob)
     -- All Mods Here Are Assigned For Initial Difficulty Tuning
-	mob:setMobMod(xi.mobMod.DRAW_IN, 1)
+    mob:setMobMod(xi.mobMod.DRAW_IN, 1)
     mob:addMod(xi.mod.MAIN_DMG_RATING, 50)
     mob:addMod(xi.mod.STR, 40)
     mob:addMod(xi.mod.VIT, 20)

--- a/scripts/zones/The_Eldieme_Necropolis_[S]/mobs/Tethra.lua
+++ b/scripts/zones/The_Eldieme_Necropolis_[S]/mobs/Tethra.lua
@@ -162,11 +162,11 @@ entity.onMobFight = function(mob, target)
         --Retaliate and Level Up
         if ability:getID() == (46) then
             mob:setLocalVar("TAbilityRetaliate", 1)
-            mob:AnimationSub(1)
+            mob:setAnimationSub(1)
         -- Level Up
         else
             mob:setLocalVar("TAbilityLevelUp", 1)
-            mob:AnimationSub(1)
+            mob:setAnimationSub(1)
         end
     end)
 

--- a/scripts/zones/The_Eldieme_Necropolis_[S]/mobs/Tethra.lua
+++ b/scripts/zones/The_Eldieme_Necropolis_[S]/mobs/Tethra.lua
@@ -48,7 +48,7 @@ end
 entity.onAdditionalEffect = function(mob, target, damage)
     -- 25% En-Petrify https://ffxiclopedia.fandom.com/wiki/Tethra
     if target:hasStatusEffect(xi.effect.PETRIFICATION) == false then
-        return xi.mob.onAddEffect(mob, target, damage, xi.mob.ae.PETRIFY, {chance = 25})
+        return xi.mob.onAddEffect(mob, target, damage, xi.mob.ae.PETRIFY, { chance = 25 })
     end
 end
 
@@ -86,61 +86,61 @@ entity.onMobFight = function(mob, target)
     end
 
     -- Combat Tick Logic
-    mob:addListener("COMBAT_TICK", "TETHRA_CTICK", function(mob)
-        local magicretaliate = mob:getLocalVar("TMagicRetaliate")
-        local abilityretaliate = mob:getLocalVar("TAbilityRetaliate")
-        local abilitylevelup = mob:getLocalVar("TAbilityLevelUp")
+    mob:addListener("COMBAT_TICK", "TETHRA_CTICK", function(mobArg)
+        local magicretaliate = mobArg:getLocalVar("TMagicRetaliate")
+        local abilityretaliate = mobArg:getLocalVar("TAbilityRetaliate")
+        local abilitylevelup = mobArg:getLocalVar("TAbilityLevelUp")
 
-        if mob:getAnimationSub() == 1 then
+        if mobArg:getAnimationSub() == 1 then
             -- Magic Retaliation Should Always Be Stone IV And Instant Cast (https://ffxiclopedia.fandom.com/wiki/Tethra)
             if magicretaliate > 0 then
                 -- Instant Cast
-                mob:setMod(xi.mod.UFASTCAST, 100)
+                mobArg:setMod(xi.mod.UFASTCAST, 100)
                 -- Cast Stone IV
-                mob:castSpell(162)
+                mobArg:castSpell(162)
                 -- Clear Vars
-                mob:setLocalVar("TMagicRetaliate", 0)
-                mob:removeListener("PLAYER_ABILITY_USED")
-                mob:setAnimationSub(0)
+                mobArg:setLocalVar("TMagicRetaliate", 0)
+                mobArg:removeListener("PLAYER_ABILITY_USED")
+                mobArg:setAnimationSub(0)
             -- Retaliates JAs With Instant Cast Stone IV and Level Up (https://ffxiclopedia.fandom.com/wiki/Tethra)
             elseif abilityretaliate > 0 then
                 -- Instant Cast
-                mob:setMod(xi.mod.UFASTCAST, 100)
+                mobArg:setMod(xi.mod.UFASTCAST, 100)
                 -- Cast Stone IV
-                mob:castSpell(162)
-                local levelupsum = mob:getLocalVar("TotalLevelUp")
+                mobArg:castSpell(162)
+                local levelupsum = mobArg:getLocalVar("TotalLevelUp")
                 -- Level Up
                 if levelupsum <= 25 then
-                    mob:useMobAbility(2460)
-                    mob:setLocalVar("TotalLevelUp", levelupsum + 1)
+                    mobArg:useMobAbility(2460)
+                    mobArg:setLocalVar("TotalLevelUp", levelupsum + 1)
                 end
                 -- Clear Vars
-                mob:setLocalVar("TAbilityRetaliate", 0)
-                mob:removeListener("PLAYER_ABILITY_USED")
-                mob:setAnimationSub(0)
+                mobArg:setLocalVar("TAbilityRetaliate", 0)
+                mobArg:removeListener("PLAYER_ABILITY_USED")
+                mobArg:setAnimationSub(0)
             -- Uses Level Up When JA Used (https://ffxiclopedia.fandom.com/wiki/Tethra)
             elseif abilitylevelup > 0 then
-                local levelupsum = mob:getLocalVar("TotalLevelUp")
+                local levelupsum = mobArg:getLocalVar("TotalLevelUp")
                 -- Level Up
                 if levelupsum <= 25 then
-                    mob:useMobAbility(2460)
-                    mob:setLocalVar("TotalLevelUp", levelupsum + 1)
+                    mobArg:useMobAbility(2460)
+                    mobArg:setLocalVar("TotalLevelUp", levelupsum + 1)
                 end
                 -- Clear Vars
-                mob:setLocalVar("TAbilityLevelUp", 0)
-                mob:removeListener("PLAYER_ABILITY_USED")
-                mob:setAnimationSub(0)
+                mobArg:setLocalVar("TAbilityLevelUp", 0)
+                mobArg:removeListener("PLAYER_ABILITY_USED")
+                mobArg:setAnimationSub(0)
             -- Resets States And Mods
             else
-                mob:setLocalVar("TAbilityLevelUp", 0)
-                mob:setLocalVar("TAbilityRetaliate", 0)
-                mob:setLocalVar("TMagicRetaliate", 0)
-                mob:setMod(xi.mod.UFASTCAST, 0)
-                mob:setAnimationSub(0)
+                mobArg:setLocalVar("TAbilityLevelUp", 0)
+                mobArg:setLocalVar("TAbilityRetaliate", 0)
+                mobArg:setLocalVar("TMagicRetaliate", 0)
+                mobArg:setMod(xi.mod.UFASTCAST, 0)
+                mobArg:setAnimationSub(0)
             end
         else
-            if mob:getCurrentAction() ~= 30 then
-                mob:setMod(xi.mod.UFASTCAST, 0)
+            if mobArg:getCurrentAction() ~= 30 then
+                mobArg:setMod(xi.mod.UFASTCAST, 0)
             end
         end
     end)
@@ -158,15 +158,15 @@ entity.onMobFight = function(mob, target)
     -- Job Ability Functions
     -- Retaliates With Instant Stone IV And Level Up If Targeted (https://ffxiclopedia.fandom.com/wiki/Tethra)
     -- Starts Level Up Sequence When Any Other Ability Is Used (https://ffxiclopedia.fandom.com/wiki/Tethra)
-    mob:addListener("PLAYER_ABILITY_USED", "TETHRA_PLAYER_ABILITY_USED", function(mob, player, ability, action, target)
+    mob:addListener("PLAYER_ABILITY_USED", "TETHRA_PLAYER_ABILITY_USED", function(mobArg, player, ability, action, target)
         --Retaliate and Level Up
         if ability:getID() == (46) then
-            mob:setLocalVar("TAbilityRetaliate", 1)
-            mob:setAnimationSub(1)
+            mobArg:setLocalVar("TAbilityRetaliate", 1)
+            mobArg:setAnimationSub(1)
         -- Level Up
         else
-            mob:setLocalVar("TAbilityLevelUp", 1)
-            mob:setAnimationSub(1)
+            mobArg:setLocalVar("TAbilityLevelUp", 1)
+            mobArg:setAnimationSub(1)
         end
     end)
 
@@ -187,9 +187,9 @@ entity.onMobFight = function(mob, target)
 
     -- Enmity Handling
     -- Mob Should Have Little To No Enmity Control (https://ffxiclopedia.fandom.com/wiki/Tethra)
-    mob:addListener("TAKE_DAMAGE", "TETHRA_TAKE_DAMAGE", function(mob, amount, attacker, attackType, damageType)
+    mob:addListener("TAKE_DAMAGE", "TETHRA_TAKE_DAMAGE", function(mobArg, amount, attacker, attackType, damageType)
         if attackType == xi.attackType.PHYSICAL then
-            mob:addEnmity(attacker, 1000, 1000)
+            mobArg:addEnmity(attacker, 1000, 1000)
         end
     end)
 
@@ -223,7 +223,7 @@ entity.onMobDisengage = function(mob)
     mob:removeListener("TEHTRA_PLAYER_ABILITY_USED")
 end
 
-entity.onMobDespawn = function(mob) 
+entity.onMobDespawn = function(mob)
     if mob:getLocalVar("MobPoof") == 1 then
         mob:showText(mob, zones[mob:getZoneID()].text.NM_DESPAWN)
         mob:setLocalVar("MobPoof", 0)
@@ -235,4 +235,4 @@ entity.onMobDeath = function(mob, player, isKiller)
     player:setTitle(xi.title.TETHRA_EXORCIST)
 end
 
-return entity 
+return entity


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

fix the CI sanity checks that are failing for abyssea la theine and tetha nm

## Steps to test these changes

should hopefully see no more CI errors
