### PR TITLE
Create Jailer_of_Prudence_2.lua

### DIFF
--- a/scripts/zones/AlTaieu/mobs/Jailer_of_Prudence_2.lua
+++ b/scripts/zones/AlTaieu/mobs/Jailer_of_Prudence_2.lua
@@ -6,8 +6,6 @@
 -----------------------------------
 local ID = require("scripts/zones/AlTaieu/IDs")
 mixins = { require("scripts/mixins/job_special") }
-mixins = {require("scripts/mixins/rage")}
-require("scripts/globals/mobs")
 require("scripts/globals/status")
 -----------------------------------
 local entity = {}

--- a/scripts/zones/AlTaieu/mobs/Jailer_of_Prudence_2.lua
+++ b/scripts/zones/AlTaieu/mobs/Jailer_of_Prudence_2.lua
@@ -1,0 +1,30 @@
+-----------------------------------
+-- Area: Al'Taieu
+-- NM: Jailer of Prudence_2
+-- Dummy file required for module functionality
+-- AnimationSubs: 0 - Normal, 3 - Mouth Open
+-----------------------------------
+local ID = require("scripts/zones/AlTaieu/IDs")
+mixins = { require("scripts/mixins/job_special") }
+mixins = {require("scripts/mixins/rage")}
+require("scripts/globals/mobs")
+require("scripts/globals/status")
+-----------------------------------
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+end
+
+entity.onMobSpawn = function(mob)
+end
+
+entity.onMobFight = function(mob, target)
+end
+
+entity.onMobDespawn = function(mob)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+end
+
+return entity


### PR DESCRIPTION


<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
This PR is part of a three part fix to give functionality to our Jailer of Prudence module. We need to distinguish between the two Jailer of Prudence monsters for over rides to correctly apply. This PR creates a dummy file for over rides to be applied to.

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Merge this PR spawn Jailer of Prudence, notice module over rides being correctly applied now.

<!-- Clear and detailed steps to test your changes here -->
