### PR TITLE
set dig limit back to 350 from 100 and zone limit back to 100 from 20

### DIFF
--- a/scripts/globals/chocobo_digging.lua
+++ b/scripts/globals/chocobo_digging.lua
@@ -848,7 +848,7 @@ local function canDig(player)
     -- neither player nor zone have reached their dig limit
 
     if
-        (digCount < 100 and zoneItemsDug < 20) or
+        (digCount < 350 and zoneItemsDug < 100) or
         xi.settings.main.DIG_FATIGUE == 0
     then
         -- pesky delays


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Customizes our Chocobo digging system. 
Set player daily dig limit to 350
Set zone daily dig limit to 100
These were the settings we had in July 2022.
Keeping other enhancements that came from LSB.

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Test if player can dig up to 100 items in one zone.
Test if player can dig up to 350 items in one day. 

<!-- Clear and detailed steps to test your changes here -->
