### PR TITLE
Remove ks bs from login campaign

### DIFF
--- a/scripts/globals/events/login_campaign_data.lua
+++ b/scripts/globals/events/login_campaign_data.lua
@@ -441,6 +441,7 @@ local prizes =
 			-- 1312, -- Angel Skin
 			-- 723, -- Divine Lumber
 			-- 720, -- Ancient Lumber
+			-- 2371, -- Khimaira Horn
 			
 			-- Cycle #2 
 			-- 1289, -- Burning Hakutaku Eye
@@ -469,6 +470,7 @@ local prizes =
 			1110, -- Beetle Blood
 			2172, -- hydra scale
 			2168, -- Cerberus Claw
+
         },
     },
 

--- a/scripts/globals/events/login_campaign_data.lua
+++ b/scripts/globals/events/login_campaign_data.lua
@@ -16,8 +16,6 @@ local prizes =
         {
         -- CONSUMABLES I
 			
-			1126, -- Beastmen's Seal
-			1127, -- Kindred's Seal
 			1455, -- 1 Byne Bill
 			1449, -- Tukuku Whiteshell
 			1452, -- Ordelle Bronzepiece


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Removes KS & BS from login_campaign_data.lua
Adds Khimaira Horn to Cycle #1 of login_campaign_data (1,000 login points)

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
This has already deployed to production by Carver.
Beastmen & Kindred Seals should not be appearing in the 10 point menu of the items.
Khimaira Horn should be appearing in 1,000 item menu.
<!-- Clear and detailed steps to test your changes here -->
