### PR TITLE
Jailer of Prudence - adding empty function for module functionality.

### DIFF
--- a/scripts/zones/AlTaieu/mobs/Jailer_of_Prudence.lua
+++ b/scripts/zones/AlTaieu/mobs/Jailer_of_Prudence.lua
@@ -55,6 +55,9 @@ entity.onMobSpawn = function(mob)
     mob:addMod(xi.mod.LULLABY_MEVA, 30)
 end
 
+entity.onMobFight = function(mob, target)
+end
+
 entity.onMobDisengage = function(mob, target)
 end
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This pull request adds an empty mob function to Jailer of Prudence to provide module functionality.

## Steps to test these changes

Load these changes.
Module over rides now function correctly.
