### PR TITLE
Added Gargouille Family functionality

### DIFF
--- a/scripts/mixins/families/gargouille.lua
+++ b/scripts/mixins/families/gargouille.lua
@@ -1,0 +1,92 @@
+-----------------------------------
+-- Gargouille family mixin
+-----------------------------------
+require("scripts/globals/mixins")
+require("scripts/globals/status")
+-----------------------------------
+g_mixins = g_mixins or {}
+g_mixins.families = g_mixins.families or {}
+
+-- This mobs switches between standing and flying at regular intervals (every 3-4 mins)
+-- Mob uses Bloody Claw in either stage, and some Gargouille NMs can also use Shadow Burst
+-- While standing, they use Terror Eye and Triumphant Roar
+-- While flying, they use Dark Mist and Dark Orb, and they receive Evasion +60 and Magic Dmg Taken -12.5%.
+
+local function flyRoaming(mob)
+    mob:setAnimationSub(5) -- Fly
+    mob:setLocalVar("formTimeRoam", os.time() + math.random(180, 240))
+    mob:setMobMod(xi.mobMod.SKILL_LIST, 117) -- Set Fly Skill List. ("Dark Mist" and "Dark Orb")
+    mob:addMod(xi.mod.EVA, 6000)
+    mob:addMod(xi.mod.DMGMAGIC, -1250)
+end
+
+local function standRoaming(mob)
+    mob:setAnimationSub(4) -- Stand
+    mob:setLocalVar("formTimeRoam", os.time() + math.random(180, 240))
+    mob:setMobMod(xi.mobMod.SKILL_LIST, 118) -- Set Standing Skill List. ("Terror Eye" and "Triumphant Roar")
+    mob:delMod(xi.mod.EVA, 6000)
+    mob:delMod(xi.mod.DMGMAGIC, -1250)
+end
+
+local function flyEngaged(mob)
+    mob:setAnimationSub(5) -- Fly
+    mob:setMobMod(xi.mobMod.SKILL_LIST, 117) -- Set Fly Skill List. ("Dark Mist" and "Dark Orb")
+    mob:addMod(xi.mod.EVA, 6000)
+    mob:addMod(xi.mod.DMGMAGIC, -1250)
+end
+
+local function standEngaged(mob)
+    mob:setAnimationSub(4) -- Stand
+    mob:setMobMod(xi.mobMod.SKILL_LIST, 118) -- Set Standing Skill List. ("Terror Eye" and "Triumphant Roar")
+    mob:delMod(xi.mod.EVA, 6000)
+    mob:delMod(xi.mod.DMGMAGIC, -1250)
+end
+
+local function resetCount(mob)
+    mob:setLocalVar("formTimeEngaged", os.time() + math.random(45, 60))
+end
+
+g_mixins.families.gargouille = function(gargouilleMob)
+    -- Set spawn.
+    gargouilleMob:addListener("SPAWN", "GARGOUILLE_SPAWN", function(mob)
+        mob:setAnimationSub(4)
+        mob:setMobMod(xi.mobMod.SKILL_LIST, 118) -- Set Standing Skill List. ("Terror Eye" and "Triumphant Roar")
+        mob:setLocalVar("formTimeRoam", os.time() + math.random(180, 240))
+        mob:setLocalVar("formTimeEngaged", os.time())
+    end)
+
+    -- Handle regular changes on roam.
+    gargouilleMob:addListener("ROAM_TICK", "GARGOUILLE_ROAM", function(mob)
+        if os.time() - mob:getLocalVar("formTimeRoam") > 0 then
+            if mob:getAnimationSub() == 4 then
+                flyRoaming(mob)
+            elseif mob:getAnimationSub() == 5 then
+                standRoaming(mob)
+            end
+        end
+    end)
+
+    -- Makes mob fly if not already upon engaging.
+    gargouilleMob:addListener("ENGAGE", "GARGOUILLE_ENGAGE", function(mob)
+        if mob:getAnimationSub() == 4 then
+            flyEngaged(mob)
+        end
+
+        resetCount(mob)
+    end)
+
+    -- Handle swapping stances in combat
+    gargouilleMob:addListener("COMBAT_TICK", "GARGOUILLE_COMBAT", function(mob)
+        if os.time() - mob:getLocalVar("formTimeEngaged") > 0 then
+            if mob:getAnimationSub() == 4 then
+                flyEngaged(mob)
+            elseif mob:getAnimationSub() == 5 then
+                standEngaged(mob)
+            end
+
+            resetCount(mob)
+        end
+    end)
+end
+
+return g_mixins.families.gargouille

--- a/scripts/zones/Beaucedine_Glacier_[S]/mobs/Gargouille.lua
+++ b/scripts/zones/Beaucedine_Glacier_[S]/mobs/Gargouille.lua
@@ -5,8 +5,18 @@
 -----------------------------------
 local ID = require("scripts/zones/Beaucedine_Glacier_[S]/IDs")
 require("scripts/globals/mobs")
+mixins = { require("scripts/mixins/families/gargouille") }
 -----------------------------------
 local entity = {}
+
+entity.onMobSpawn = function(mob)
+end
+
+entity.onMobRoam = function(mob)
+end
+
+entity.onMobFight = function(mob, target)
+end
 
 entity.onMobDeath = function(mob, player, optParams)
 end


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

(Pairs with the gargouille_modules branch in the modules repo)

Added Gargouille Family functionality.

Mixin file and the addition of the requirement line of the mob lua need to implemented in the base repo because there's way to use an override for these changes.

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
