### PR TITLE
Fixed message for sparkshop

### DIFF
--- a/scripts/globals/sparkshop.lua
+++ b/scripts/globals/sparkshop.lua
@@ -698,7 +698,7 @@ function xi.sparkshop.onEventUpdate(player, csid, option, npc)
             end
 
             if currency.name == "obsidian_fragment" then
-                player:PrintToPlayer("You are not allowed to receive Kinetic Units in this way.", 17)
+                player:PrintToPlayer("You are not allowed to receive Obsidian Fragments in this way.", 17)
             else
                 player:addCurrency(currency.name, currency.amount * qty, getCurrencyCap(currency.name))
             end


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

Fixed sparkshop message to reflect Obsidian Fragments, not Kinetic Units.

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
