### PR TITLE
Modified CI to not include claim_shield.lua

### DIFF
--- a/tools/ci/lua_stylecheck.py
+++ b/tools/ci/lua_stylecheck.py
@@ -27,6 +27,10 @@ deprecated_functions = [
     ["table.getn", "#t"],
 ]
 
+excluded_filenames = [
+    'scripts/mixins/claim_shield.lua',
+]
+
 def contains_word(word):
     return re.compile(r'\b({0})\b'.format(word)).search
 
@@ -354,7 +358,8 @@ expected_errors = 0
 
 if target == 'scripts':
     for filename in glob.iglob('scripts/**/*.lua', recursive = True):
-        total_errors += LuaStyleCheck(filename).errcount
+        if filename not in excluded_filenames:
+            total_errors += LuaStyleCheck(filename).errcount
 elif target == 'test':
     total_errors = LuaStyleCheck('tools/ci/tests/stylecheck.lua', show_errors = False).errcount
     expected_errors = 41


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Modifies the CI to not include the `claim_shield.lua` file as that includes HTML and I/O functions that are not `lua`.

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->

Make a change to `claim_shield.lua` and see if CI runs on it.