### PR TITLE
[lua] Correct carver's torque itemID on Nolan.

### DIFF
--- a/scripts/zones/Norg/npcs/Nolan.lua
+++ b/scripts/zones/Norg/npcs/Nolan.lua
@@ -142,6 +142,7 @@ entity.onTrigger = function(player, npc)
     local page6 = {}
     local page7 = {}
     local page8 = {}
+    local page9 = {}
 
     local delaySendMenu = function(playerArg)
         player:timer(100, function(playerArgMenu)

--- a/scripts/zones/Norg/npcs/Nolan.lua
+++ b/scripts/zones/Norg/npcs/Nolan.lua
@@ -44,13 +44,13 @@ local unlockWs = function(player, npc, ws)
             {
                 "Yes, I'm sure!",
                 function(playerArg)
-                    player:timer(100, function(playerArg)
+                    player:timer(100, function(playerArgMenu)
                         if beadsBalance >= wsCost and ws == paidWs then
-                            player:setCurrency("escha_beads", beadsBalance - wsCost)
-                            player:setCharVar("PaidForMeritWs", 0)
-                            player:setCharVar("Afterglow", 1)
-                            player:setCharVar(wsTable[ws][1], 1)
-                            player:PrintToPlayer("\129\153\129\154 Congratulations! You've unlocked a new Weaponskill! \129\154\129\153\n", 0, npc:getPacketName())
+                            playerArgMenu:setCurrency("escha_beads", beadsBalance - wsCost)
+                            playerArgMenu:setCharVar("PaidForMeritWs", 0)
+                            playerArgMenu:setCharVar("Afterglow", 1)
+                            playerArgMenu:setCharVar(wsTable[ws][1], 1)
+                            playerArgMenu:PrintToPlayer("\129\153\129\154 Congratulations! You've unlocked a new Weaponskill! \129\154\129\153\n", 0, npc:getPacketName())
                         else
                             if ws > 15 or ws < 2 then
                                 player:PrintToPlayer("DEBUG: Incorrect value for variable `ws`. Please contact an administrator.", 0, npc:getPacketName()) -- This message should NEVER trigger.
@@ -130,6 +130,7 @@ end
 entity.onTrigger = function(player, npc)
     local beadsBalance = player:getCurrency("escha_beads")
     local item         = 0
+    local cost         = 0
 
     -- Forward declarations (required)
     local menu  = {}
@@ -142,9 +143,9 @@ entity.onTrigger = function(player, npc)
     local page7 = {}
     local page8 = {}
 
-    local delaySendMenu = function(player)
-        player:timer(100, function(playerArg)
-            playerArg:customMenu(menu)
+    local delaySendMenu = function(playerArg)
+        player:timer(100, function(playerArgMenu)
+            playerArgMenu:customMenu(menu)
         end)
     end
 
@@ -162,7 +163,7 @@ entity.onTrigger = function(player, npc)
         {
             "Pearlscale (grants Elvorseal)",
             function(playerArg)
-                player:timer(50, function(playerArg)
+                playerArg:timer(50, function(playerArgMenu)
                     item = 5714
                     cost = 250
                     completeTransaction(player, npc, item, cost)
@@ -172,7 +173,7 @@ entity.onTrigger = function(player, npc)
         {
             "Siren's hair",
             function(playerArg)
-                player:timer(50, function(playerArg)
+                player:timer(50, function(playerArgMenu)
                     item = 1313
                     cost = 5000
                     completeTransaction(player, npc, item, cost)
@@ -182,7 +183,7 @@ entity.onTrigger = function(player, npc)
         {
             "Scintillant ingot",
             function(playerArg)
-                player:timer(50, function(playerArg)
+                player:timer(50, function(playerArgMenu)
                     item = 2275
                     cost = 5000
                     completeTransaction(player, npc, item, cost)
@@ -203,7 +204,7 @@ entity.onTrigger = function(player, npc)
         {
             "Teleport ring: Holla",
             function(playerArg)
-                player:timer(50, function(playerArg)
+                player:timer(50, function(playerArgMenu)
                     item = 14661
                     cost = 5000
                     completeTransaction(player, npc, item, cost)
@@ -213,7 +214,7 @@ entity.onTrigger = function(player, npc)
         {
             "Teleport ring: Mea",
             function(playerArg)
-                player:timer(50, function(playerArg)
+                player:timer(50, function(playerArgMenu)
                     item = 14662
                     cost = 5000
                     completeTransaction(player, npc, item, cost)
@@ -223,7 +224,7 @@ entity.onTrigger = function(player, npc)
         {
             "Teleport ring: Dem",
             function(playerArg)
-                player:timer(50, function(playerArg)
+                player:timer(50, function(playerArgMenu)
                     item = 14663
                     cost = 5000
                     completeTransaction(player, npc, item, cost)
@@ -244,7 +245,7 @@ entity.onTrigger = function(player, npc)
         {
             "Emico mantle",
             function(playerArg)
-                player:timer(50, function(playerArg)
+                player:timer(50, function(playerArgMenu)
                     item = 27597
                     cost = 10000
                     completeTransaction(player, npc, item, cost)
@@ -254,7 +255,7 @@ entity.onTrigger = function(player, npc)
         {
             "Crested torque",
             function(playerArg)
-                player:timer(50, function(playerArg)
+                player:timer(50, function(playerArgMenu)
                     item = 28349
                     cost = 10000
                     completeTransaction(player, npc, item, cost)
@@ -264,7 +265,7 @@ entity.onTrigger = function(player, npc)
         {
             "Setae ring",
             function(playerArg)
-                player:timer(50, function(playerArg)
+                player:timer(50, function(playerArgMenu)
                     item = 28529
                     cost = 10000
                     completeTransaction(player, npc, item, cost)
@@ -274,7 +275,7 @@ entity.onTrigger = function(player, npc)
         {
             "Megasco earring",
             function(playerArg)
-                player:timer(50, function(playerArg)
+                player:timer(50, function(playerArgMenu)
                     item = 28488
                     cost = 10000
                     completeTransaction(player, npc, item, cost)
@@ -284,7 +285,7 @@ entity.onTrigger = function(player, npc)
         {
             "Salire belt",
             function(playerArg)
-                player:timer(50, function(playerArg)
+                player:timer(50, function(playerArgMenu)
                     item = 28425
                     cost = 10000
                     completeTransaction(player, npc, item, cost)
@@ -294,7 +295,7 @@ entity.onTrigger = function(player, npc)
         {
             "Charitoni sling",
             function(playerArg)
-                player:timer(50, function(playerArg)
+                player:timer(50, function(playerArgMenu)
                     item = 21347
                     cost = 10000
                     completeTransaction(player, npc, item, cost)
@@ -315,7 +316,7 @@ entity.onTrigger = function(player, npc)
         {
             "Dew silk cape",
             function(playerArg)
-                player:timer(50, function(playerArg)
+                player:timer(50, function(playerArgMenu)
                     item = 27598
                     cost = 10000
                     completeTransaction(player, npc, item, cost)
@@ -325,7 +326,7 @@ entity.onTrigger = function(player, npc)
         {
             "Adsilio boots",
             function(playerArg)
-                player:timer(50, function(playerArg)
+                player:timer(50, function(playerArgMenu)
                     item = 28271
                     cost = 10000
                     completeTransaction(player, npc, item, cost)
@@ -335,7 +336,7 @@ entity.onTrigger = function(player, npc)
         {
             "Fylgja torque",
             function(playerArg)
-                player:timer(50, function(playerArg)
+                player:timer(50, function(playerArgMenu)
                     item = 11579
                     cost = 15000
                     completeTransaction(player, npc, item, cost)
@@ -345,7 +346,7 @@ entity.onTrigger = function(player, npc)
         {
             "Dew silk cape +1",
             function(playerArg)
-                player:timer(50, function(playerArg)
+                player:timer(50, function(playerArgMenu)
                     item = 27599
                     cost = 15000
                     completeTransaction(player, npc, item, cost)
@@ -355,7 +356,7 @@ entity.onTrigger = function(player, npc)
         {
             "Adsilio boots +1",
             function(playerArg)
-                player:timer(50, function(playerArg)
+                player:timer(50, function(playerArgMenu)
                     item = 28272
                     cost = 15000
                     completeTransaction(player, npc, item, cost)
@@ -376,7 +377,7 @@ entity.onTrigger = function(player, npc)
         {
             "Carver's torque",
             function(playerArg)
-                player:timer(50, function(playerArg)
+                player:timer(50, function(playerArgMenu)
                     item = 10948
                     cost = 15000
                     completeTransaction(player, npc, item, cost)
@@ -386,7 +387,7 @@ entity.onTrigger = function(player, npc)
         {
             "Tanner's torque",
             function(playerArg)
-                player:timer(50, function(playerArg)
+                player:timer(50, function(playerArgMenu)
                     item = 10952
                     cost = 15000
                     completeTransaction(player, npc, item, cost)
@@ -396,7 +397,7 @@ entity.onTrigger = function(player, npc)
         {
             "Smithy's torque",
             function(playerArg)
-                player:timer(50, function(playerArg)
+                player:timer(50, function(playerArgMenu)
                     item = 10949
                     cost = 15000
                     completeTransaction(player, npc, item, cost)
@@ -406,7 +407,7 @@ entity.onTrigger = function(player, npc)
         {
             "Goldsmith's torque",
             function(playerArg)
-                player:timer(50, function(playerArg)
+                player:timer(50, function(playerArgMenu)
                     item = 10950
                     cost = 15000
                     completeTransaction(player, npc, item, cost)
@@ -416,7 +417,7 @@ entity.onTrigger = function(player, npc)
         {
             "Boneworker's torque",
             function(playerArg)
-                player:timer(50, function(playerArg)
+                player:timer(50, function(playerArgMenu)
                     item = 10953
                     cost = 15000
                     completeTransaction(player, npc, item, cost)
@@ -426,7 +427,7 @@ entity.onTrigger = function(player, npc)
         {
             "Weaver's torque",
             function(playerArg)
-                player:timer(50, function(playerArg)
+                player:timer(50, function(playerArgMenu)
                     item = 10951
                     cost = 15000
                     completeTransaction(player, npc, item, cost)
@@ -447,7 +448,7 @@ entity.onTrigger = function(player, npc)
         {
             "Alchemist's torque",
             function(playerArg)
-                player:timer(50, function(playerArg)
+                player:timer(50, function(playerArgMenu)
                     item = 10954
                     cost = 15000
                     completeTransaction(player, npc, item, cost)
@@ -457,7 +458,7 @@ entity.onTrigger = function(player, npc)
         {
             "Culinarian torque",
             function(playerArg)
-                player:timer(50, function(playerArg)
+                player:timer(50, function(playerArgMenu)
                     item = 10955
                     cost = 15000
                     completeTransaction(player, npc, item, cost)
@@ -467,7 +468,7 @@ entity.onTrigger = function(player, npc)
         {
             "Fylgja torque +1",
             function(playerArg)
-                player:timer(50, function(playerArg)
+                player:timer(50, function(playerArgMenu)
                     item = 11580
                     cost = 25000
                     completeTransaction(player, npc, item, cost)

--- a/scripts/zones/Norg/npcs/Nolan.lua
+++ b/scripts/zones/Norg/npcs/Nolan.lua
@@ -50,7 +50,7 @@ local unlockWs = function(player, npc, ws)
                             player:setCharVar("PaidForMeritWs", 0)
                             player:setCharVar("Afterglow", 1)
                             player:setCharVar(wsTable[ws][1], 1)
-                            player:PrintToPlayer("\129\153\129\154 Congratulations! You've unlocked a new Weaponskill! \129\154\129\153\n", 0, npc:getPacketName())                
+                            player:PrintToPlayer("\129\153\129\154 Congratulations! You've unlocked a new Weaponskill! \129\154\129\153\n", 0, npc:getPacketName())
                         else
                             if ws > 15 or ws < 2 then
                                 player:PrintToPlayer("DEBUG: Incorrect value for variable `ws`. Please contact an administrator.", 0, npc:getPacketName()) -- This message should NEVER trigger.
@@ -85,9 +85,7 @@ end
 
 local completeTransaction = function(player, npc, item, cost)
     local beadsBalance = player:getCurrency("escha_beads")
-    local paidForWs    = player:getCharVar("PaidForMeritWs")
-
-    local confirmMenu  = 
+    local confirmMenu  =
     {
         title = string.format("Spend %i points? (%i available)", cost, beadsBalance),
         onStart = function(playerArg)
@@ -490,7 +488,7 @@ entity.onTrigger = function(player, npc)
         {
             "Apex Arrow (Bow)",
             function(playerArg)
-               unlockWs(player, npc, 14)
+                unlockWs(player, npc, 14)
             end,
         },
         {

--- a/scripts/zones/Norg/npcs/Nolan.lua
+++ b/scripts/zones/Norg/npcs/Nolan.lua
@@ -379,7 +379,7 @@ entity.onTrigger = function(player, npc)
             "Carver's torque",
             function(playerArg)
                 player:timer(50, function(playerArg)
-                    item = 11580
+                    item = 10948
                     cost = 15000
                     completeTransaction(player, npc, item, cost)
                 end)

--- a/scripts/zones/Norg/npcs/Nolan.lua
+++ b/scripts/zones/Norg/npcs/Nolan.lua
@@ -9,7 +9,7 @@ local ID = require("scripts/zones/Norg/IDs")
 -----------------------------------
 local entity = {}
 
-local wsTable = 
+local wsTable =
 {
 -- index           varName
     [2]  = { "hasShijinSpiralUnlock", },
@@ -25,7 +25,7 @@ local wsTable =
     [12] = { "hasRealmrazerUnlock",   },
     [13] = { "hasShattersoulUnlock",  },
     [14] = { "hasApexArrowUnlock",    },
-    [15] = { "hasLastStandUnlock",    }, 
+    [15] = { "hasLastStandUnlock",    },
 }
 
 local unlockWs = function(player, npc, ws)
@@ -70,14 +70,14 @@ local unlockWs = function(player, npc, ws)
                 end,
             },
         },
-        
+
         onCancelled = function(playerArg)
         end,
-        
+
         onEnd = function(playerArg)
         end,
     }
-    
+
     player:timer(150, function(playerArg)
         player:customMenu(menu)
     end)
@@ -86,7 +86,7 @@ end
 local completeTransaction = function(player, npc, item, cost)
     local beadsBalance = player:getCurrency("escha_beads")
     local paidForWs    = player:getCharVar("PaidForMeritWs")
-    
+
     local confirmMenu  = 
     {
         title = string.format("Spend %i points? (%i available)", cost, beadsBalance),
@@ -115,15 +115,15 @@ local completeTransaction = function(player, npc, item, cost)
                 end,
             },
         },
-        
+
         onCancelled = function(playerArg)
         end,
 
         onEnd = function(playerArg)
         end,
     }
-    
-    player:customMenu(confirmMenu)            
+
+    player:customMenu(confirmMenu)
 end
 
 entity.onTrade = function(player, npc, trade)
@@ -143,7 +143,7 @@ entity.onTrigger = function(player, npc)
     local page6 = {}
     local page7 = {}
     local page8 = {}
-    
+
     local delaySendMenu = function(player)
         player:timer(100, function(playerArg)
             playerArg:customMenu(menu)
@@ -152,13 +152,13 @@ entity.onTrigger = function(player, npc)
 
     -- Print Beads balance
     player:PrintToPlayer(string.format("You have %s escha beads available to spend. Choose wisely.", beadsBalance), 0, npc:getPacketName())
-    
+
     menu =
     {
         title = "Choose a reward",
         options = {},
     }
-    
+
     page1 =
     {
         {
@@ -197,9 +197,9 @@ entity.onTrigger = function(player, npc)
                 menu.options = page2
                 delaySendMenu(playerArg)
             end,
-        },        
+        },
     }
-    
+
     page2 =
     {
         {
@@ -238,9 +238,9 @@ entity.onTrigger = function(player, npc)
                 menu.options = page3
                 delaySendMenu(playerArg)
             end,
-        },        
+        },
     }
-    
+
     page3 =
     {
         {
@@ -309,9 +309,9 @@ entity.onTrigger = function(player, npc)
                 menu.options = page4
                 delaySendMenu(playerArg)
             end,
-        },        
+        },
     }
-    
+
     page4 =
     {
         {
@@ -370,11 +370,11 @@ entity.onTrigger = function(player, npc)
                 menu.options = page5
                 delaySendMenu(playerArg)
             end,
-        },        
+        },
     }
-    
+
     page5 =
-	{
+    {
         {
             "Carver's torque",
             function(playerArg)
@@ -441,11 +441,11 @@ entity.onTrigger = function(player, npc)
                 menu.options = page6
                 delaySendMenu(playerArg)
             end,
-        },        
+        },
     }
-    
+
     page6 =
-	{
+    {
         {
             "Alchemist's torque",
             function(playerArg)
@@ -482,9 +482,9 @@ entity.onTrigger = function(player, npc)
                 menu.options = page7
                 delaySendMenu(playerArg)
             end,
-        },        
+        },
     }
-    
+
     page7 =
     {
         {
@@ -495,31 +495,31 @@ entity.onTrigger = function(player, npc)
         },
         {
             "Blade: Shun (Katana)",
-            function(playerArg)                         
+            function(playerArg)
                 unlockWs(player, npc, 10)
             end,
         },
         {
             "Entropy (Scythe)",
-            function(playerArg)     
+            function(playerArg)
                 unlockWs(player, npc, 8)
             end,
         },
         {
             "Exenterator (Dagger)",
-            function(playerArg)                         
+            function(playerArg)
                 unlockWs(player, npc, 3)
             end,
         },
         {
             "Last Stand (Gun)",
-            function(playerArg)                         
+            function(playerArg)
                 unlockWs(player, npc, 15)
             end,
         },
         {
             "Realmrazer (Club)",
-            function(playerArg)                         
+            function(playerArg)
                 unlockWs(player, npc, 12)
             end,
         },
@@ -529,44 +529,44 @@ entity.onTrigger = function(player, npc)
                 menu.options = page8
                 delaySendMenu(playerArg)
             end,
-        },        
+        },
     }
-    
+
     page8 =
     {
         {
             "Requiescat (Sword)",
-            function(playerArg)                         
+            function(playerArg)
                 unlockWs(player, npc, 4)
             end,
         },
         {
             "Resolution (Great Sword)",
-            function(playerArg)                         
+            function(playerArg)
                 unlockWs(player, npc, 5)
             end,
         },
         {
             "Ruinator (Axe)",
-            function(playerArg)                         
+            function(playerArg)
                 unlockWs(player, npc, 6)
             end,
         },
         {
             "Shattersoul (Staff)",
-            function(playerArg)                         
+            function(playerArg)
                 unlockWs(player, npc, 13)
             end,
         },
         {
             "Shijin Spiral (H2H)",
-            function(playerArg) 
-                unlockWs(player, npc, 2)            
+            function(playerArg)
+                unlockWs(player, npc, 2)
             end,
         },
         {
             "Stardiver (Pole)",
-            function(playerArg)                         
+            function(playerArg)
                 unlockWs(player, npc, 9)
             end,
         },
@@ -576,20 +576,20 @@ entity.onTrigger = function(player, npc)
                 menu.options = page9
                 delaySendMenu(playerArg)
             end,
-        },        
+        },
     }
-    
+
     page9 =
     {
         {
             "Tachi: Shoha (Great Katana)",
-            function(playerArg)                         
+            function(playerArg)
                 unlockWs(player, npc, 11)
             end,
         },
         {
             "Upheaval (Great Axe)",
-            function(playerArg)                         
+            function(playerArg)
                 unlockWs(player, npc, 7)
             end,
         },
@@ -598,9 +598,9 @@ entity.onTrigger = function(player, npc)
             function(playerArg)
                 return
             end,
-        },        
+        },
     }
-    
+
     menu.options = page1
     delaySendMenu(player)
 end


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Adds the correct item ID for carver's torque.
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Load this change, buy carver's torque from Nolan.
<!-- Clear and detailed steps to test your changes here -->
