### PR TITLE
Implement SATA interaction with physical Blue Magic

### DIFF
--- a/scripts/globals/bluemagic.lua
+++ b/scripts/globals/bluemagic.lua
@@ -224,13 +224,13 @@ xi.spells.blue.usePhysicalSpell = function(caster, target, spell, params)
     local hitslanded = 0
     local finaldmg = 0
     local sneakIsApplicable = caster:hasStatusEffect(xi.effect.SNEAK_ATTACK) and
-                              spell:isAoE() == 0 and
-                              params.attackType ~= xi.attackType.RANGED and
-                              (caster:isBehind(target) or caster:hasStatusEffect(xi.effect.HIDE))
+                                spell:isAoE() == 0 and
+                                params.attackType ~= xi.attackType.RANGED and
+                                (caster:isBehind(target) or caster:hasStatusEffect(xi.effect.HIDE))
     local trickAttackTarget = (caster:hasStatusEffect(xi.effect.TRICK_ATTACK) and
-                              spell:isAoE() == 0 and
-                              params.attackType ~= xi.attackType.RANGED) and
-                              caster:getTrickAttackChar(target) or nil
+                                spell:isAoE() == 0 and
+                                params.attackType ~= xi.attackType.RANGED) and
+                                caster:getTrickAttackChar(target) or nil
 
     while hitsdone < params.numhits do
         local chance = math.random()
@@ -428,6 +428,7 @@ xi.spells.blue.applySpellDamage = function(caster, target, spell, dmg, params, t
     dmg = utils.stoneskin(target, dmg)
 
     target:takeSpellDamage(caster, spell, dmg, attackType, damageType)
+
     if not target:isPC() then
         if trickAttackTarget then
             target:updateEnmityFromDamage(trickAttackTarget, dmg)
@@ -435,6 +436,7 @@ xi.spells.blue.applySpellDamage = function(caster, target, spell, dmg, params, t
             target:updateEnmityFromDamage(caster, dmg)
         end
     end
+
     target:handleAfflatusMiseryDamage(dmg)
 
     return dmg

--- a/scripts/globals/bluemagic.lua
+++ b/scripts/globals/bluemagic.lua
@@ -223,10 +223,14 @@ xi.spells.blue.usePhysicalSpell = function(caster, target, spell, params)
     local hitsdone = 0
     local hitslanded = 0
     local finaldmg = 0
+    local sneakIsApplicable = caster:hasStatusEffect(xi.effect.SNEAK_ATTACK) and
+                              spell:isAoE() == 0 and
+                              params.attackType ~= xi.attackType.RANGED and
+                              (caster:isBehind(target) or caster:hasStatusEffect(xi.effect.HIDE))
 
     while hitsdone < params.numhits do
         local chance = math.random()
-        if chance <= hitrate then -- it hit
+        if sneakIsApplicable or chance <= hitrate then -- it hit
             -- TODO: Check for shadow absorbs. Right now the whole spell will be absorbed by one shadow before it even gets here.
 
             -- Generate a random pDIF between min and max
@@ -234,18 +238,27 @@ xi.spells.blue.usePhysicalSpell = function(caster, target, spell, params)
             pdif = pdif / 1000
 
             -- Add it to our final damage
-            if hitsdone == 0 then
-                finaldmg = finaldmg + (finalD * (multiplier + correlationMultiplier) * pdif) -- first hit gets full multiplier
+            if hitsdone == 0 then -- first hit gets full multiplier
+                if sneakIsApplicable then
+                    finaldmg = finaldmg + (finalD * (multiplier + correlationMultiplier) * (pdif + 0.7))
+                else
+                    finaldmg = finaldmg + (finalD * (multiplier + correlationMultiplier) * pdif)
+                end
             else
                 finaldmg = finaldmg + (finalD * (1 + correlationMultiplier) * pdif)
             end
 
+            sneakIsApplicable = false
             hitslanded = hitslanded + 1
 
             -- increment target's TP (100TP per hit landed)
             if finaldmg > 0 then
                 target:addTP(100)
             end
+        end
+
+        if params.attackType ~= xi.attackType.RANGED then
+            caster:delStatusEffect(xi.effect.SNEAK_ATTACK)
         end
 
         hitsdone = hitsdone + 1

--- a/scripts/globals/spells/blue/1000_needles.lua
+++ b/scripts/globals/spells/blue/1000_needles.lua
@@ -51,7 +51,7 @@ spellObject.onSpellCast = function(caster, target, spell)
     if resist == 1 then
         local targets = spell:getTotalTargets()
         damage = damage / targets
-        damage = xi.spells.blue.applySpellDamage(caster, target, spell, damage, params)
+        damage = xi.spells.blue.applySpellDamage(caster, target, spell, damage, params, nil)
     else
         spell:setMsg(xi.msg.basic.MAGIC_RESIST)
     end

--- a/scripts/globals/spells/blue/self-destruct.lua
+++ b/scripts/globals/spells/blue/self-destruct.lua
@@ -32,7 +32,7 @@ spellObject.onSpellCast = function(caster, target, spell)
     local damage = playerHP - 1
 
     if damage > 0 then
-        damage = xi.spells.blue.applySpellDamage(caster, target, spell, damage, params)
+        damage = xi.spells.blue.applySpellDamage(caster, target, spell, damage, params, nil)
         caster:setHP(1)
         caster:delStatusEffectSilent(xi.effect.WEAKNESS)
         caster:addStatusEffect(xi.effect.WEAKNESS, 1, 0, 300)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
With these changes Sneak Attack and Trick Attack should work with physical Blue Magic.

Credit goes to Wings developers, I based this implementation on theirs here: https://gitlab.com/ffxiwings/wings/-/blob/master/scripts/globals/bluemagic.lua

## Steps to test these changes

1. !changejob thf
2. !setplayerlevel 75
3. !changejob blu
4. !setplayerlevel 75
5. !changesjob thf
6. !addallspells
7. Summon a trust
8. Use TA, line up and cast Cannonball
9. Observe as you get no enmity (!getenmity)
