### PR TITLE
Dancer Mythic Fixes

### DIFF
--- a/scripts/globals/items.lua
+++ b/scripts/globals/items.lua
@@ -4153,6 +4153,7 @@ xi.items =
     FAUCHEUSE                       = 18952,
     GLEAMING_ZAGHNAL                = 18963,
     DIRE_SCYTHE                     = 18964,
+    TERPSICHORE                     = 18989,
     SWORD_STRAP                     = 19024,
     POLE_GRIP                       = 19025,
     SPEAR_STRAP                     = 19026,

--- a/scripts/globals/job_utils/dancer.lua
+++ b/scripts/globals/job_utils/dancer.lua
@@ -6,6 +6,7 @@ require('scripts/globals/magic')
 require('scripts/globals/msg')
 require('scripts/globals/status')
 require('scripts/globals/weaponskills')
+require('scripts/globals/items')
 -----------------------------------
 xi = xi or {}
 xi.job_utils = xi.job_utils or {}
@@ -57,13 +58,16 @@ end
 -- TODO: Determine if step is stacked at 10, and reduce to 1 if necessary.
 local function getStepFinishingMovesBase(player)
     local numAwardedMoves = 1
-
     if player:hasStatusEffect(xi.effect.PRESTO) then
         numAwardedMoves = 5
     elseif player:getMainJob() == xi.job.DNC then
         numAwardedMoves = 2
     end
-
+--- If Terpsichore is equipped, adds 1 additional finishing move to player (custom)
+    if player:getEquipID(xi.slot.MAIN) == xi.items.TERPSICHORE or player:getEquipID(xi.slot.SUB) == xi.items.TERPSICHORE then
+        numAwardedMoves = numAwardedMoves + 1
+    end
+--- End of custom code
     return numAwardedMoves
 end
 

--- a/scripts/globals/job_utils/dancer.lua
+++ b/scripts/globals/job_utils/dancer.lua
@@ -64,7 +64,10 @@ local function getStepFinishingMovesBase(player)
         numAwardedMoves = 2
     end
 --- If Terpsichore is equipped, adds 1 additional finishing move to player (custom)
-    if player:getEquipID(xi.slot.MAIN) == xi.items.TERPSICHORE or player:getEquipID(xi.slot.SUB) == xi.items.TERPSICHORE then
+    if
+        player:getEquipID(xi.slot.MAIN) == xi.items.TERPSICHORE or
+        player:getEquipID(xi.slot.SUB) == xi.items.TERPSICHORE
+    then
         numAwardedMoves = numAwardedMoves + 1
     end
 --- End of custom code


### PR DESCRIPTION
…lobal

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This PR adds Terpsichore to the items global lua.  This PR also adds a check to steps that looks to see if Terpsichore is equipped by the player, and will grant an additional finishing move if it is.

## Steps to test these changes

Equip Terpsichore in main or sub slot, perform any of the steps (Box step, Sutter Step, etc) and it will provide the player with 3 finishing moves per step instead of the 2 from having Dancer set as main job.
