### PR TITLE
Rebuild trait list after zoning

### DIFF
--- a/src/map/utils/zoneutils.cpp
+++ b/src/map/utils/zoneutils.cpp
@@ -35,7 +35,11 @@
 #include "mob_modifier.h"
 #include "mob_spell_list.h"
 #include "mobutils.h"
+#include "packets/char_abilities.h"
+#include "packets/char_job_extra.h"
+#include "packets/char_stats.h"
 #include "packets/entity_update.h"
+#include "utils/charutils.h"
 #include "zone_instance.h"
 
 #include <algorithm>
@@ -1209,6 +1213,16 @@ namespace zoneutils
         }
 
         luautils::AfterZoneIn(PChar);
+
+        if (PChar != nullptr && PChar->objtype == TYPE_PC)
+        {
+            charutils::BuildingCharTraitsTable(PChar);
+            PChar->pushPacket(new CCharAbilitiesPacket(PChar));
+            PChar->pushPacket(new CCharJobExtraPacket(PChar, true));
+            PChar->pushPacket(new CCharJobExtraPacket(PChar, false));
+            PChar->pushPacket(new CCharStatsPacket(PChar));
+            PChar->UpdateHealth();
+        }
     }
 
 }; // namespace zoneutils


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This fixes the issue where Blue Mages would lose their traits after zoning or even after they first log in.
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes

1. !addspell 612 \<me\>
2. !addspell 615 \<me\>
3. Equip both spells to get auto-refresh, observe how the trait now sticks after zoning
<!-- Clear and detailed steps to test your changes here -->
