### PR TITLE
Do not track changes when the HEAD of modules/main changes

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,9 +4,11 @@
 [submodule "modules/catseyexi"]
 	path = modules/catseyexi
 	url = https://github.com/catsandboats/modules
+	ignore = all
 [submodule "modules/contrib"]
 	path = modules/contrib
 	url = https://github.com/CatsAndBoats/contrib
+	ignore = all
 [submodule "navmeshes"]
 	path = navmeshes
 	url = https://github.com/CatsAndBoats/xiNavmeshes


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Simple change to get rid of `modules/*` submodule changes being tracked in base repo

i.e. this
![image](https://github.com/CatsAndBoats/catseyexi/assets/131182600/6ca653c0-462e-4557-b805-7e4eb9343c72)

turns into this
![image](https://github.com/CatsAndBoats/catseyexi/assets/131182600/9a516bd5-842b-4e17-882c-06f7b48a1dcb)

no matter which branch in modules is checked out

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
