### PR TITLE
typo in regimes.lua

### DIFF
--- a/scripts/globals/regimes.lua
+++ b/scripts/globals/regimes.lua
@@ -1508,7 +1508,7 @@ xi.regime.checkRegime = function(player, mob, regimeId, index, regimeType)
     if player:getMainLvl() >= math.max(1, page[5] - xi.settings.main.REGIME_REWARD_THRESHOLD) then
         if
             (player:isCrystalWarrior() or player:isClassicMode()) and
-            (player:partyHighestLevel > page[6] - 6)
+            (player:partyHighestLevel() >= page[6] - 6)
         then
             local completions = player:getCharVar("[regime]repeatedToday")
 
@@ -1541,3 +1541,4 @@ xi.regime.checkRegime = function(player, mob, regimeId, index, regimeType)
         xi.regime.clearRegimeVars(player)
     end
 end
+


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

PR to track hotfixes from today's maintenance
- Typo in recent change to `regimes.lua`