### PR TITLE
Make full page credit scale on level of party

### DIFF
--- a/scripts/globals/regimes.lua
+++ b/scripts/globals/regimes.lua
@@ -1450,8 +1450,8 @@ xi.regime.checkRegime = function(player, mob, regimeId, index, regimeType)
         reward = math.floor(reward * avgCapLevel / avgMobLevel)
     end
 
-    -- Preserve baseReward amount for CW EXP
-    local baseReward = reward
+    -- Preserve baseReward amount for CW EXP and scale on EXP_BONUS mod
+    local baseReward = reward * player:getMod(xi.mod.EXP_BONUS)
 
     -- prowess buffs from completing Grounds regimes
     if regimeType == xi.regime.type.GROUNDS then
@@ -1506,9 +1506,11 @@ xi.regime.checkRegime = function(player, mob, regimeId, index, regimeType)
     -- Award EXP for page completion
     -- Player must be equal or greater than REGIME_REWARD_THRESHOLD levels below the minimum suggested level
     if player:getMainLvl() >= math.max(1, page[5] - xi.settings.main.REGIME_REWARD_THRESHOLD) then
+        local highestLevel = player:partyHighestLevel()
+        local pageLevelDiff = 2 + math.ceil(highestLevel / 20)
         if
             (player:isCrystalWarrior() or player:isClassicMode()) and
-            (player:partyHighestLevel() >= page[6] - 6)
+            (page[6] - highestLevel < pageLevelDiff)
         then
             local completions = player:getCharVar("[regime]repeatedToday")
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Slight adjustment to the level requirements to get full page credit. scales linearly from 3 level difference at 10 to 6 level difference at 75

Also adjusts the page xp to scale based on EXP_BONUS mod. This seems like an oversight in core code but I don't have retail to test it.

EXP_BONUS is used by moghancements and I would assume they should increase page xp? Core handles dedication and EXP_BONUS in a function that's only called when you gain xp from a mob

## Steps to test these changes

do pages on EP mobs as wew or cw, see that you get diminishing returns

do pages when max level of page is greater than the threshold based on the highest level in your party:

`2 + math.ceil(highestLevel / 20)`

and see that you get no diminishing returns