### PR TITLE
Reduce AH listing time from 60 days to 42 days. (8 weeks to 6)

### DIFF
--- a/settings/default/search.lua
+++ b/settings/default/search.lua
@@ -18,7 +18,7 @@ xi.settings.search =
     EXPIRE_AUCTIONS = true,
 
     -- Expire items older than this number of days
-    EXPIRE_DAYS = 60,
+    EXPIRE_DAYS = 42,
 
     -- Interval is in seconds, default is one hour
     EXPIRE_INTERVAL = 3600,


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x ] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x ] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x ] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Changes the AH expiration date before sending items back from 60 days to 42 days as discussed. Next week will be the new determined resting spot of 30 days, as per the meeting.

## Steps to test these changes

Basic addendum.
