### PR TITLE
Disable The Boyahda Tree GoV Page 8

### DIFF
--- a/scripts/globals/regimes.lua
+++ b/scripts/globals/regimes.lua
@@ -502,7 +502,7 @@ local regimeInfo =
                     { 3, 4, 0, 0, 72, 76, 1830, 723 },
                     { 4, 3, 0, 0, 72, 78, 1900, 724 },
                     { 3, 3, 0, 0, 74, 78, 1900, 725 },
-                    { 2, 2, 2, 0, 74, 78, 1900, 726 },
+--                    { 2, 2, 2, 0, 74, 78, 1900, 726 },  -- Disabled as pages 4-7 are level 72-78 mobs, and page 8 was originally level 102-104. Targets made into a merit camp. Can't imbalance merit camps by only one having a book, nor do merit camps need books.
                 },
             },
             [xi.zone.MIDDLE_DELKFUTTS_TOWER] =


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

GoV Page 8 in the tree was originally level 102-104 monsters. It has it's own little room of a bunch of these endgame merit mobs. On our server they were changed to ~75, which is at or lower than the mobs of page 4,5,6, and 7.

As a result these mobs on page 8 were turned into a new merit camp rather than create irrelevant targets in the very target rich environment that the tree is. No other camp has a book for merit mobs, nor does it need one. That would create an imbalance, and there are 7 other pages to do in the tree.

As a result, I am requesting this page be disabled so that this merit camp can be realized. Otherwise, the monsters need to stay the same level as the ones for pages 4-7.

## Steps to test these changes

Just commented out the last page after conferring with Mowford on if that works or not.

Tested on my local and the page just doesnt appear, all seems good.
