### PR TITLE
Claim shield dedupe by id fix

### DIFF
--- a/modules/custom/lua/claim_shield.lua
+++ b/modules/custom/lua/claim_shield.lua
@@ -65,8 +65,8 @@ end
 -- Using entity ids: dedupe a table in-place
 local dedupeByID = function(t)
     local seen = {}
-	for i = #t, 1, -1 do --counting backwards to make table.remove a safe operation
-		--adding a cleanup step in the process, removing entries with an empty or 0-length name
+    for i = #t, 1, -1 do --counting backwards to make table.remove a safe operation
+        --adding a cleanup step in the process, removing entries with an empty or 0-length name
         if t[i] and t[i]:getName():match('^%s*$') or seen[t[i]:getID()] then
             table.remove(t, i)
         else

--- a/modules/custom/lua/claim_shield.lua
+++ b/modules/custom/lua/claim_shield.lua
@@ -65,11 +65,12 @@ end
 -- Using entity ids: dedupe a table in-place
 local dedupeByID = function(t)
     local seen = {}
-    for index, entity in ipairs(t) do
-        if seen[entity:getID()] then
-            table.remove(t, index)
+	for i = #t, 1, -1 do --counting backwards to make table.remove a safe operation
+		--adding a cleanup step in the process, removing entries with an empty or 0-length name
+        if t[i] and t[i]:getName():match('^%s*$') or seen[t[i]:getID()] then
+            table.remove(t, i)
         else
-            seen[entity:getID()] = true
+            seen[t[i]:getID()] = true
         end
     end
 end

--- a/modules/custom/lua/claim_shield.lua
+++ b/modules/custom/lua/claim_shield.lua
@@ -66,7 +66,7 @@ end
 local dedupeByID = function(t)
     local seen = {}
     for i = #t, 1, -1 do --counting backwards to make table.remove a safe operation
-        --adding a cleanup step in the process, removing entries with an empty or 0-length name
+        --adding a cleanup step in the process, removing entries with an whitespaces or 0-length name
         if t[i] and t[i]:getName():match('^%s*$') or seen[t[i]:getID()] then
             table.remove(t, i)
         else


### PR DESCRIPTION
I affirm:
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Fixes the function dedupeByID in the claim_shield.lua file by safely parsing the input table right-to-left.

## Steps to test these changes
1. Have multiple entities with the same ID engaging an NM protected by Claim Shield
2. Before the the winner is announced check the "entries" table
3. Confirm that there are no duplicated entities (same ID)
4. Confirm that there are no entities with 0-length or all-whitespace names