### PR TITLE
Update Rugiette.lua

### DIFF
--- a/scripts/zones/Port_San_dOria/npcs/Rugiette.lua
+++ b/scripts/zones/Port_San_dOria/npcs/Rugiette.lua
@@ -8,12 +8,7 @@
 local entity = {}
 
 entity.onTrigger = function(player, npc)
-    local wildcatSandy = player:getCharVar('WildcatSandy')
-
-    if
-        player:getQuestStatus(xi.questLog.SANDORIA, xi.quest.id.sandoria.LURE_OF_THE_WILDCAT) == xi.questStatus.QUEST_ACCEPTED and
-        not utils.mask.getBit(wildcatSandy, 14)
-    then
+    if player:getQuestStatus(xi.questLog.SANDORIA, xi.quest.id.sandoria.LURE_OF_THE_WILDCAT) == xi.questStatus.QUEST_ACCEPTED then
         player:startEvent(746)
     else
         player:startEvent(601)
@@ -22,7 +17,11 @@ end
 
 entity.onEventFinish = function(player, csid, option, npc)
     if csid == 746 then
-        player:setCharVar('WildcatSandy', utils.mask.setBit(player:getCharVar('WildcatSandy'), 14, true))
+        local wildcatSandy = player:getCharVar('WildcatSandy')
+        if not utils.mask.getBit(wildcatSandy, 14) then
+            player:setCharVar('WildcatSandy', utils.mask.setBit(wildcatSandy, 14, true))
+            npcUtil.giveQuestItem(player, xi.questLog.SANDORIA, xi.quest.id.sandoria.LURE_OF_THE_WILDCAT, 1)
+        end
     end
 end
 


### PR DESCRIPTION
removed bitmask check in onTrigger; event 746 now allowed to replay during QUEST_ACCEPTED. onEventFinish sets bit 14 and calls npcUtil.giveQuestItem to ensure badge progress increments correctly.

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
